### PR TITLE
Display logo variants and add kinetic typography module

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,6 +78,7 @@ body{
 .sprite{ position:absolute; width:clamp(24px,2.6vw,34px); transform-origin:50% 60%;
          opacity:.95; filter:drop-shadow(0 2px 2px rgba(0,0,0,.12)); animation:floatY var(--dur,6s) ease-in-out infinite }
 .sprite svg{ display:block; width:100%; height:auto }
+.invert{ filter:brightness(0) invert(1); }
 .sprite .wing{ animation:flap var(--flap,1200ms) ease-in-out infinite; }
 @keyframes flap{ 0%,100%{ transform:rotate(0) } 50%{ transform:rotate(var(--arc,14deg)) } }
 @keyframes floatY{ 0%,100%{ transform:translateY(-6px) rotate(var(--start,0deg)) } 50%{ transform:translateY(6px) rotate(var(--end,-2deg)) } }
@@ -184,8 +185,12 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           <img src="../assets/logo-top-1.svg" alt="Logo on light" style="width:72%;height:auto"/>
         </div>
         <div class="stage" style="aspect-ratio:1/1; background:#111">
-          <img src="../assets/logo-alt-bg.svg" alt="Logo on dark" style="width:72%;height:auto"/>
+          <img src="../assets/logo-top-1.svg" alt="Logo on dark" class="invert" style="width:72%;height:auto"/>
         </div>
+      </div>
+      <div class="actions" style="margin-top:10px">
+        <a class="btn" href="../assets/logo-top-1.svg" download>Download SVG</a>
+        <button onclick="downloadPNG('../assets/logo-top-1.svg','logo-top-1.png')">PNG</button>
       </div>
     </div>
   </section>

--- a/frontend/kinetic-typography.html
+++ b/frontend/kinetic-typography.html
@@ -73,74 +73,9 @@
     <div class="particles" id="particles"></div>
   </div>
 
-<script>
-(function(){
-  const logoHolder = document.getElementById('logoHolder');
-  const particles = document.getElementById('particles');
-
-  fetch('../assets/logo-alt-kinetic.svg')
-    .then(r=>r.text())
-    .then(svgText=>{
-      logoHolder.innerHTML = svgText;
-      init();
-    });
-
-  const R = (a,b)=> a + Math.random()*(b-a);
-
-  function spawn(kind, x, y, drift){
-    const el = document.createElement('div');
-    el.className = 'sprite ' + kind;
-    const sv = document.createElementNS('http://www.w3.org/2000/svg','svg');
-    sv.setAttribute('viewBox','0 0 100 80');
-    const use = document.createElementNS('http://www.w3.org/2000/svg','use');
-    use.setAttributeNS('http://www.w3.org/1999/xlink','href', kind==='bird' ? '#BIRD_RIG' : '#BUTTER_RIG');
-    sv.appendChild(use); el.appendChild(sv); particles.appendChild(el);
-    const host = particles.getBoundingClientRect();
-    const px = x - host.left, py = y - host.top;
-    el.style.setProperty('--x', px+'px'); el.style.setProperty('--y', py+'px');
-    let dx = R(160,240), dy = R(-320,-200);
-    if(drift==='left') dx = -dx;
-    const mx = dx*0.45, my = dy*0.45;
-    el.style.setProperty('--mx', Math.round(mx)+'px');
-    el.style.setProperty('--my', Math.round(my)+'px');
-    el.style.setProperty('--dx', Math.round(dx)+'px');
-    el.style.setProperty('--dy', Math.round(dy)+'px');
-    el.style.setProperty('--r0', R(-10,10)+'deg');
-    el.style.setProperty('--rm', R(-10,10)+'deg');
-    el.style.setProperty('--r1', R(-28,18)+'deg');
-    el.style.setProperty('--s', R(.95,1.15));
-    el.style.setProperty('--flap', (kind==='bird'? R(380,480):R(320,420))+'ms');
-    el.style.setProperty('--dur', Math.round(R(2400,3200))+'ms');
-    requestAnimationFrame(()=> el.classList.add('fly'));
-    el.addEventListener('animationend', ()=> el.remove(), {once:true});
-  }
-
-  function centerOf(el){ const r = el.getBoundingClientRect(); return {x:r.left+r.width*0.5, y:r.top+r.height*0.5}; }
-
-  function init(){
-    const svgRoot = logoHolder.querySelector('svg');
-    const bird = svgRoot ? svgRoot.querySelector('#Bird, #bird') : null;
-    const butter = svgRoot ? svgRoot.querySelector('#Butterfly, #butterfly') : null;
-    if (bird) {
-      bird.style.cursor = 'pointer';
-      bird.addEventListener('mouseenter', ()=>{
-        const a = centerOf(bird);
-        spawn('bird', a.x, a.y, 'right');
-      });
-    }
-    if (butter) {
-      butter.style.cursor = 'pointer';
-      butter.addEventListener('mouseenter', ()=>{
-        const a = centerOf(butter);
-        spawn('butter', a.x, a.y, 'left');
-      });
-    }
-    svgRoot.addEventListener('click', (ev)=>{
-      const n = Math.round(R(24, 36));
-      for(let i=0;i<n;i++) setTimeout(()=> spawn(Math.random()<.55?'bird':'butter', ev.clientX, ev.clientY, Math.random()<.5?'left':'right'), i*32);
-    });
-  }
-})();
+<script type="module">
+import { initKineticTypography } from './kinetic-typography.js';
+initKineticTypography();
 </script>
 </body>
 </html>

--- a/frontend/kinetic-typography.js
+++ b/frontend/kinetic-typography.js
@@ -1,0 +1,71 @@
+export function initKineticTypography({
+  logoHolderId = 'logoHolder',
+  particlesId = 'particles',
+  svgPath = '../assets/logo-alt-kinetic.svg'
+} = {}){
+  const logoHolder = document.getElementById(logoHolderId);
+  const particles = document.getElementById(particlesId);
+
+  fetch(svgPath)
+    .then(r=>r.text())
+    .then(svgText=>{
+      logoHolder.innerHTML = svgText;
+      setupInteractions();
+    });
+
+  const R = (a,b)=> a + Math.random()*(b-a);
+
+  function spawn(kind, x, y, drift){
+    const el = document.createElement('div');
+    el.className = 'sprite ' + kind;
+    const sv = document.createElementNS('http://www.w3.org/2000/svg','svg');
+    sv.setAttribute('viewBox','0 0 100 80');
+    const use = document.createElementNS('http://www.w3.org/2000/svg','use');
+    use.setAttributeNS('http://www.w3.org/1999/xlink','href', kind==='bird' ? '#BIRD_RIG' : '#BUTTER_RIG');
+    sv.appendChild(use); el.appendChild(sv); particles.appendChild(el);
+    const host = particles.getBoundingClientRect();
+    const px = x - host.left, py = y - host.top;
+    el.style.setProperty('--x', px+'px'); el.style.setProperty('--y', py+'px');
+    let dx = R(160,240), dy = R(-320,-200);
+    if(drift==='left') dx = -dx;
+    const mx = dx*0.45, my = dy*0.45;
+    el.style.setProperty('--mx', Math.round(mx)+'px');
+    el.style.setProperty('--my', Math.round(my)+'px');
+    el.style.setProperty('--dx', Math.round(dx)+'px');
+    el.style.setProperty('--dy', Math.round(dy)+'px');
+    el.style.setProperty('--r0', R(-10,10)+'deg');
+    el.style.setProperty('--rm', R(-10,10)+'deg');
+    el.style.setProperty('--r1', R(-28,18)+'deg');
+    el.style.setProperty('--s', R(.95,1.15));
+    el.style.setProperty('--flap', (kind==='bird'? R(380,480):R(320,420))+'ms');
+    el.style.setProperty('--dur', Math.round(R(2400,3200))+'ms');
+    requestAnimationFrame(()=> el.classList.add('fly'));
+    el.addEventListener('animationend', ()=> el.remove(), {once:true});
+  }
+
+  function centerOf(el){ const r = el.getBoundingClientRect(); return {x:r.left+r.width*0.5, y:r.top+r.height*0.5}; }
+
+  function setupInteractions(){
+    const svgRoot = logoHolder.querySelector('svg');
+    const bird = svgRoot ? svgRoot.querySelector('#Bird, #bird') : null;
+    const butter = svgRoot ? svgRoot.querySelector('#Butterfly, #butterfly') : null;
+    if (bird) {
+      bird.style.cursor = 'pointer';
+      bird.addEventListener('mouseenter', ()=>{
+        const a = centerOf(bird);
+        spawn('bird', a.x, a.y, 'right');
+      });
+    }
+    if (butter) {
+      butter.style.cursor = 'pointer';
+      butter.addEventListener('mouseenter', ()=>{
+        const a = centerOf(butter);
+        spawn('butter', a.x, a.y, 'left');
+      });
+    }
+    svgRoot.addEventListener('click', (ev)=>{
+      const n = Math.round(R(24, 36));
+      for(let i=0;i<n;i++) setTimeout(()=> spawn(Math.random()<.55?'bird':'butter', ev.clientX, ev.clientY, Math.random()<.5?'left':'right'), i*32);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Use the same `logo-top-1.svg` for both light and dark logo usage examples with a new `invert` filter class.
- Provide adjacent SVG/PNG download controls for the primary logo variant.
- Add reusable `kinetic-typography` module and update demo page to import it.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a2c92ab0c832ab8402f3c1b0fec51