### PR TITLE
Use Sora for cleaner brand-guide headings

### DIFF
--- a/brand-guide.html
+++ b/brand-guide.html
@@ -4,13 +4,15 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>A Grief Like Mine – Brand Guide</title>
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@300..700&display=swap" rel="stylesheet">
 <style>
-  body { font-family: Arial, sans-serif; margin:40px; line-height:1.6; background:#f9f9f9; color:#333; }
-  h1,h2 { color:#333; }
+  body { font-family: 'Sora', sans-serif; margin:40px; line-height:1.6; background:#f9f9f9; color:#333; }
+  h1 { color:#333; font-weight:600; letter-spacing:.01em; }
+  h2 { color:#333; font-weight:500; letter-spacing:.01em; }
   .logo-grid { display:flex; flex-wrap:wrap; gap:20px; }
   .logo-grid figure { width:300px; text-align:center; margin:0; }
   .logo-grid img { max-width:100%; height:auto; border:1px solid #ddd; background:#fff; padding:10px; border-radius:4px; }
-  .logo-grid figcaption { margin-top:8px; font-weight:bold; }
+  .logo-grid figcaption { margin-top:8px; font-weight:500; }
   .colors { display:flex; flex-wrap:wrap; gap:20px; margin-top:20px; }
   .color { width:120px; font-size:14px; }
   .swatch { width:100%; height:60px; border-radius:4px; margin-bottom:6px; }


### PR DESCRIPTION
## Summary
- switch brand-guide to Sora webfont
- lighten heading and caption weights for easier reading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a40116608832aa4bd7f46f77a6834