### PR TITLE
Use PNG logos and improve mobile layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,6 +40,7 @@ body{
   font-family: Quicksand, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
   line-height:1.4;
 }
+img{max-width:100%;height:auto}
 
 .container{max-width:1200px; margin:0 auto; padding:28px 20px 80px}
 .header{
@@ -55,10 +56,10 @@ body{
   width:14px; height:14px; border-radius:50%; background:var(--blue1);
   box-shadow:0 0 0 6px color-mix(in srgb, var(--blue1) 12%, transparent);
 }
-.brand h1{font-family:Righteous, sans-serif; font-size:18px; margin:0; letter-spacing:.08em}
+.brand h1{font-family:Righteous, sans-serif; font-size:clamp(16px,4.5vw,18px); margin:0; letter-spacing:.08em}
 .header nav{display:flex; gap:14px; flex-wrap:wrap}
 .header a{
-  text-decoration:none; color:var(--ink); font-size:14px; opacity:.85; padding:6px 10px; border-radius:8px;
+  text-decoration:none; color:var(--ink); font-size:clamp(13px,4vw,14px); opacity:.85; padding:6px 10px; border-radius:8px;
 }
 .header a:hover{ background:color-mix(in srgb, var(--blue2) 15%, transparent); }
 
@@ -70,7 +71,7 @@ body{
 
 /* Hero */
 .hero{ position:relative; border-radius:22px; padding:28px; overflow:hidden; background:var(--card); box-shadow:var(--shadow) }
-.hero h2{ font-family: Faculty Glyphic, serif; margin:0 0 10px; font-size:26px; letter-spacing:.02em }
+.hero h2{ font-family: Faculty Glyphic, serif; margin:0 0 10px; font-size:clamp(22px,6vw,26px); letter-spacing:.02em }
 .hero p{ margin:0; color:var(--muted) }
 
 /* Floating sprites — idle only */
@@ -129,10 +130,12 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
 @media (max-width:600px){
   .grid{grid-template-columns:1fr;}
   .header{flex-direction:column; align-items:flex-start;}
+  .header nav{flex-direction:column; width:100%;}
+  .header nav a{display:block;}
 }
 
 /* Section headings */
-h3.section{ font-family: Faculty Glyphic, serif; margin:28px 0 12px; font-size:22px; letter-spacing:.02em }
+h3.section{ font-family: Faculty Glyphic, serif; margin:28px 0 12px; font-size:clamp(20px,5vw,22px); letter-spacing:.02em }
 
 footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
 
@@ -169,11 +172,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <div class="card" style="grid-column: span 7;">
       <h3 class="section">Main Logo — “A Grief Like Mine — 1×1 Center”</h3>
       <div class="stage" id="logoStage">
-        <object id="brandLogo" data="../assets/logo-alt-bg.svg" type="image/svg+xml" style="width:72%;height:auto"></object>
+        <img id="brandLogo" src="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" alt="A Grief Like Mine centered logo" style="width:72%;height:auto"/>
         <div class="overlay-note">Centered 1×1 composition</div>
       </div>
       <div class="actions">
-        <button id="exportPNG">Download PNG (transparent, 3000×3000)</button>
+        <a class="btn" href="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" download>Download PNG (transparent, 3000×3000)</a>
         <button class="secondary" id="toggleBG">Toggle Preview BG</button>
       </div>
       <div style="margin-top:10px; color:#555; font-size:13px">
@@ -192,15 +195,15 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:10px">
         <div style="display:flex; flex-direction:column; align-items:center; gap:6px">
           <div class="stage" style="aspect-ratio:1/1; background:#fff">
-            <img src="../assets/logo-top-1.svg" alt="Logo on light" style="width:72%;height:auto"/>
+            <img src="../assets/A-Grief-Like-Mine-1x1-center.png" alt="Logo on light" style="width:72%;height:auto"/>
           </div>
-          <a class="btn" href="../assets/logo-top-1.svg" download>Download SVG</a>
+          <a class="btn" href="../assets/A-Grief-Like-Mine-1x1-center.png" download>Download PNG</a>
         </div>
         <div style="display:flex; flex-direction:column; align-items:center; gap:6px">
           <div class="stage" style="aspect-ratio:1/1; background:#111">
-            <img src="../assets/logo-top-1.svg" alt="Logo on dark" class="invert" style="width:72%;height:auto"/>
+            <img src="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" alt="Logo on dark" class="invert" style="width:72%;height:auto"/>
           </div>
-          <button onclick="downloadPNG('../assets/logo-top-1.svg','logo-top-1.png')">PNG</button>
+          <a class="btn" href="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" download>Download PNG</a>
         </div>
       </div>
     </div>
@@ -210,15 +213,15 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-top:10px">
         <div style="display:flex; flex-direction:column; align-items:center; gap:6px">
           <div class="stage" style="aspect-ratio:1/1; background:#fff">
-            <img src="../assets/logo-top-3.svg" alt="Top 3 logo on light" style="width:72%;height:auto"/>
+            <img src="../assets/AGLM-Symbols_3D_logo.png" alt="Top 3 logo on light" style="width:72%;height:auto"/>
           </div>
-          <a class="btn" href="../assets/logo-top-3.svg" download>Download SVG</a>
+          <a class="btn" href="../assets/AGLM-Symbols_3D_logo.png" download>Download PNG</a>
         </div>
         <div style="display:flex; flex-direction:column; align-items:center; gap:6px">
           <div class="stage" style="aspect-ratio:1/1; background:#111">
-            <img src="../assets/logo-top-3.svg" alt="Top 3 logo on dark" class="invert" style="width:72%;height:auto"/>
+            <img src="../assets/AGLM-Symbols_3D_logo.png" alt="Top 3 logo on dark" class="invert" style="width:72%;height:auto"/>
           </div>
-          <button onclick="downloadPNG('../assets/logo-top-3.svg','logo-top-3.png')">PNG</button>
+          <a class="btn" href="../assets/AGLM-Symbols_3D_logo.png" download>Download PNG</a>
         </div>
       </div>
     </div>
@@ -281,15 +284,15 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <h3 class="section">Social Templates</h3>
     <div class="templates">
       <div class="frame">
-        <div class="canvas square"><img src="../assets/logo-top-1.svg" alt="1x1 template" style="width:80%;height:auto"/></div>
+        <div class="canvas square"><img src="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" alt="1x1 template" style="width:80%;height:auto"/></div>
         <div style="font-size:12px; margin-top:6px; color:#555">Profile / Grid</div>
       </div>
       <div class="frame">
-        <div class="canvas portrait"><img src="../assets/logo-top-2.svg" alt="4x5 template" style="width:80%;height:auto"/></div>
+        <div class="canvas portrait"><img src="../assets/AGLM-Illustration_3D_logo-large.png" alt="4x5 template" style="width:80%;height:auto"/></div>
         <div style="font-size:12px; margin-top:6px; color:#555">IG Portrait</div>
       </div>
       <div class="frame">
-        <div class="canvas landscape"><img src="../assets/logo-top-3.svg" alt="16x9 template" style="width:80%;height:auto"/></div>
+        <div class="canvas landscape"><img src="../assets/AGLM-Symbols_3D_logo.png" alt="16x9 template" style="width:80%;height:auto"/></div>
         <div style="font-size:12px; margin-top:6px; color:#555">Video / YouTube</div>
       </div>
     </div>
@@ -309,38 +312,27 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <h3 class="section">Logo Downloads</h3>
     <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:20px">
       <div class="card" style="box-shadow:none">
-        <img src="../assets/logo-top-1.svg" alt="Logo top 1" style="width:100%;height:auto"/>
+        <img src="../assets/A-Grief-Like-Mine-1x1-center.png" alt="1x1 centered logo" style="width:100%;height:auto"/>
         <div class="actions" style="margin-top:10px">
-          <a class="btn" href="../assets/logo-top-1.svg" download>Download SVG</a>
-          <button onclick="downloadPNG('../assets/logo-top-1.svg','logo-top-1.png')">PNG</button>
+          <a class="btn" href="../assets/A-Grief-Like-Mine-1x1-center.png" download>Download PNG</a>
         </div>
       </div>
       <div class="card" style="box-shadow:none">
-        <img src="../assets/logo-top-2.svg" alt="Logo top 2" style="width:100%;height:auto"/>
+        <img src="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" alt="1x1 centered logo transparent" style="width:100%;height:auto"/>
         <div class="actions" style="margin-top:10px">
-          <a class="btn" href="../assets/logo-top-2.svg" download>Download SVG</a>
-          <button onclick="downloadPNG('../assets/logo-top-2.svg','logo-top-2.png')">PNG</button>
+          <a class="btn" href="../assets/A-Grief-Like-Mine-1x1-center-[transparent].png" download>Download PNG</a>
         </div>
       </div>
       <div class="card" style="box-shadow:none">
-        <img src="../assets/logo-top-3.svg" alt="Logo top 3" style="width:100%;height:auto"/>
+        <img src="../assets/AGLM-Symbols_3D_logo.png" alt="Symbols 3D logo" style="width:100%;height:auto"/>
         <div class="actions" style="margin-top:10px">
-          <a class="btn" href="../assets/logo-top-3.svg" download>Download SVG</a>
-          <button onclick="downloadPNG('../assets/logo-top-3.svg','logo-top-3.png')">PNG</button>
+          <a class="btn" href="../assets/AGLM-Symbols_3D_logo.png" download>Download PNG</a>
         </div>
       </div>
       <div class="card" style="box-shadow:none">
-        <img src="../assets/logo-alt-bg.svg" alt="Logo alt bg" style="width:100%;height:auto"/>
+        <img src="../assets/AGLM-Illustration_3D_logo-large.png" alt="Illustration 3D logo" style="width:100%;height:auto"/>
         <div class="actions" style="margin-top:10px">
-          <a class="btn" href="../assets/logo-alt-bg.svg" download>Download SVG</a>
-          <button onclick="downloadPNG('../assets/logo-alt-bg.svg','logo-alt-bg.png')">PNG</button>
-        </div>
-      </div>
-      <div class="card" style="box-shadow:none">
-        <img src="../assets/logo-alt-kinetic.svg" alt="Logo alt kinetic" style="width:100%;height:auto"/>
-        <div class="actions" style="margin-top:10px">
-          <a class="btn" href="../assets/logo-alt-kinetic.svg" download>Download SVG</a>
-          <button onclick="downloadPNG('../assets/logo-alt-kinetic.svg','logo-alt-kinetic.png')">PNG</button>
+          <a class="btn" href="../assets/AGLM-Illustration_3D_logo-large.png" download>Download PNG</a>
         </div>
       </div>
     </div>
@@ -411,76 +403,18 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   setTimeout(()=> spawn('butter'), 600);
 })();
 
-// Export PNG (transparent) for the centered logo
+// Toggle preview background for centered logo
 (function(){
-  const btn = document.getElementById('exportPNG');
   const toggle = document.getElementById('toggleBG');
   const stage = document.getElementById('logoStage');
-  const svgObj = document.getElementById('brandLogo');
-
-  async function exportPNG(){
-    const size = 3000;
-    const svgText = await fetch(svgObj.data).then(r=>r.text());
-    const svgBlob = new Blob([svgText], {type:'image/svg+xml;charset=utf-8'});
-    const url = URL.createObjectURL(svgBlob);
-    const img = new Image();
-    img.onload = function(){
-      const canvas = document.createElement('canvas');
-      canvas.width = size; canvas.height = size;
-      const ctx = canvas.getContext('2d');
-      ctx.clearRect(0,0,size,size);
-      const scale = 0.72;
-      const s = size * scale;
-      const x = (size - s)/2;
-      const y = (size - s)/2;
-      ctx.drawImage(img, x, y, s, s);
-      canvas.toBlob((blob)=>{
-        const a = document.createElement('a');
-        a.download = 'AGLM_Logo_1x1_center_3000.png';
-        a.href = URL.createObjectURL(blob);
-        a.click();
-        URL.revokeObjectURL(a.href);
-      }, 'image/png');
-    };
-    img.src = url;
-  }
 
   function toggleBG(){
     const current = getComputedStyle(stage).backgroundColor;
     stage.style.background = current === 'rgba(0, 0, 0, 0)' || current === 'transparent' ? 'var(--neutral3)' : 'transparent';
   }
 
-  btn?.addEventListener('click', exportPNG);
   toggle?.addEventListener('click', toggleBG);
 })();
-
-// generic SVG -> PNG downloader for variant assets
-async function downloadPNG(src, filename){
-  try{
-    const svgText = await fetch(src).then(r=>r.text());
-    const svgBlob = new Blob([svgText], {type:'image/svg+xml;charset=utf-8'});
-    const url = URL.createObjectURL(svgBlob);
-    const img = new Image();
-    img.onload = function(){
-      const canvas = document.createElement('canvas');
-      canvas.width = img.width; canvas.height = img.height;
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(img,0,0);
-      URL.revokeObjectURL(url);
-      canvas.toBlob(function(blob){
-        const a=document.createElement('a');
-        a.href=URL.createObjectURL(blob);
-        a.download=filename;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-      },'image/png');
-    };
-    img.src = url;
-  }catch(err){
-    console.error('PNG download failed', err);
-  }
-}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace placeholder SVG references with actual PNG logo assets on the brand kit page
- Add responsive image and typography rules and stack navigation on small screens
- Remove unused SVG export scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a424dfdc0832a83357c65b41121bb