### PR TITLE
Add responsive brand kit page with fullscreen logos

### DIFF
--- a/brand-guide.html
+++ b/brand-guide.html
@@ -1,80 +1,66 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>A Grief Like Mine – Brand Guide</title>
-<link href="https://fonts.googleapis.com/css2?family=Sora:wght@300..700&display=swap" rel="stylesheet">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>A GRIEF LIKE MINE — Brand Kit (2025)</title>
+<link href="https://fonts.googleapis.com/css2?family=Modak&family=Sora:wght@300..800&display=swap" rel="stylesheet">
 <style>
-  body { font-family: 'Sora', sans-serif; margin:40px; line-height:1.6; background:#f9f9f9; color:#333; }
-  h1 { color:#333; font-weight:600; letter-spacing:.01em; }
-  h2 { color:#333; font-weight:500; letter-spacing:.01em; }
-  .logo-grid { display:flex; flex-wrap:wrap; gap:20px; }
-  .logo-grid figure { width:300px; text-align:center; margin:0; }
-  .logo-grid img { max-width:100%; height:auto; border:1px solid #ddd; background:#fff; padding:10px; border-radius:4px; }
-  .logo-grid figcaption { margin-top:8px; font-weight:500; }
-  .colors { display:flex; flex-wrap:wrap; gap:20px; margin-top:20px; }
-  .color { width:120px; font-size:14px; }
-  .swatch { width:100%; height:60px; border-radius:4px; margin-bottom:6px; }
+body{margin:0;font-family:'Sora',sans-serif;background:#f7f6f3;color:#111;line-height:1.45;}
+.container{max-width:900px;margin:0 auto;padding:20px;}
+h1{font-family:'Modak',cursive;font-size:32px;text-align:center;margin:20px 0;}
+.section{margin-top:32px;}
+.logo-stage{position:relative;display:flex;justify-content:center;align-items:center;background:#f3f0ec;border-radius:20px;aspect-ratio:1/1;overflow:hidden;}
+.logo-stage img{max-width:70%;height:auto;}
+.logo-grid{display:flex;flex-wrap:wrap;gap:20px;justify-content:center;}
+.logo-grid .logo-stage{flex:1 1 260px;}
+.fs-btn{position:absolute;top:10px;right:10px;width:28px;height:28px;background:rgba(0,0,0,.55);color:#fff;border:none;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+.fs-btn:hover{background:rgba(0,0,0,.75);}
+@media(max-width:600px){.logo-grid{flex-direction:column;align-items:center;}}
 </style>
 </head>
 <body>
-<h1>A Grief Like Mine – Brand Guide</h1>
+<div class="container">
+  <h1>A GRIEF LIKE MINE — Brand Kit</h1>
 
-<section>
-<h2>Primary Logos</h2>
-<div class="logo-grid">
-  <figure>
-    <img src="assets/logo-top-1.svg" alt="Logo Top Choice 1" />
-    <figcaption>Top Choice 1</figcaption>
-  </figure>
-  <figure>
-    <img src="assets/logo-top-2.svg" alt="Logo Top Choice 2" />
-    <figcaption>Top Choice 2</figcaption>
-  </figure>
-  <figure>
-    <img src="assets/logo-top-3.svg" alt="Logo Top Choice 3" />
-    <figcaption>Top Choice 3</figcaption>
-  </figure>
+  <section class="section" id="logo">
+    <h2>Main Logo</h2>
+    <div class="logo-stage">
+      <img src="https://i.ibb.co/N2Lr6c4s/A-Grief-Like-Mine-1x1-center.png" alt="A Grief Like Mine logo">
+      <button class="fs-btn" aria-label="Full screen">&#x2197;</button>
+    </div>
+    <p style="margin-top:10px;text-align:center;">Centered 1×1 mark. Maintain “G” height clearspace. Minimum size 32px.</p>
+
+    <div class="logo-grid">
+      <div class="logo-stage" style="background:#fff;">
+        <img src="https://i.ibb.co/mCGyLQ0D/A-Grief-Like-Mine-1x1-center-transparent.png" alt="Logo on light background">
+        <button class="fs-btn" aria-label="Full screen">&#x2197;</button>
+      </div>
+      <div class="logo-stage" style="background:#111;">
+        <img src="https://i.ibb.co/mCGyLQ0D/A-Grief-Like-Mine-1x1-center-transparent.png" alt="Logo on dark background">
+        <button class="fs-btn" aria-label="Full screen">&#x2197;</button>
+      </div>
+      <div class="logo-stage">
+        <img src="https://i.ibb.co/chVL645z/AGLM-Symbols-3-D-logo-large.png" alt="AGLM Symbols 3D logo">
+        <button class="fs-btn" aria-label="Full screen">&#x2197;</button>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" id="type">
+    <h2>Typography</h2>
+    <p style="font-family:'Modak',cursive;font-size:28px;">Modak — Display font</p>
+    <p style="font-family:'Sora',sans-serif;">Sora — Body and UI font. The sea remembers. We move gently, not swiftly.</p>
+  </section>
 </div>
-</section>
 
-<section>
-<h2>Alternate Logos</h2>
-<div class="logo-grid">
-  <figure>
-    <img src="assets/logo-alt-bg.svg" alt="Alternate logo with background" />
-    <figcaption>Alternate – Background</figcaption>
-  </figure>
-  <figure>
-    <img src="assets/logo-alt-kinetic.svg" alt="Kinetic typography logo" />
-    <figcaption>Alternate – Kinetic Typography</figcaption>
-  </figure>
-</div>
-</section>
-
-<section>
-<h2>Brand Colors</h2>
-<div class="colors">
-  <div class="color"><div class="swatch" style="background:#a56645"></div><code>#a56645</code></div>
-  <div class="color"><div class="swatch" style="background:#a8aaad"></div><code>#a8aaad</code></div>
-  <div class="color"><div class="swatch" style="background:#3363a6"></div><code>#3363a6</code></div>
-  <div class="color"><div class="swatch" style="background:#5f8ab9"></div><code>#5f8ab9</code></div>
-  <div class="color"><div class="swatch" style="background:#a98173"></div><code>#a98173</code></div>
-  <div class="color"><div class="swatch" style="background:#de9146"></div><code>#de9146</code></div>
-  <div class="color"><div class="swatch" style="background:#e1ccbf"></div><code>#e1ccbf</code></div>
-  <div class="color"><div class="swatch" style="background:#47465d"></div><code>#47465d</code></div>
-  <div class="color"><div class="swatch" style="background:#8db4c1"></div><code>#8db4c1</code></div>
-  <div class="color"><div class="swatch" style="background:#bf9e90"></div><code>#bf9e90</code></div>
-  <div class="color"><div class="swatch" style="background:#cab4a7"></div><code>#cab4a7</code></div>
-  <div class="color"><div class="swatch" style="background:#8598a1"></div><code>#8598a1</code></div>
-  <div class="color"><div class="swatch" style="background:#3d4b78"></div><code>#3d4b78</code></div>
-  <div class="color"><div class="swatch" style="background:#dc9049"></div><code>#dc9049</code></div>
-  <div class="color"><div class="swatch" style="background:#6c7085"></div><code>#6c7085</code></div>
-  <div class="color"><div class="swatch" style="background:#f3f0ec; border:1px solid #ccc"></div><code>#f3f0ec</code></div>
-</div>
-<p>The palette above is derived from the primary logo.</p>
-</section>
-
+<script>
+document.querySelectorAll('.fs-btn').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const img=btn.parentElement.querySelector('img');
+    if(img.requestFullscreen){img.requestFullscreen();}
+  });
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Embed primary, transparent, and alternate logos with fullscreen toggle
- Showcase Modak and Sora typography in a mobile-friendly layout

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a4f6c361c832ab7e0525f6f8181bb