### PR TITLE
Improve logo sampling and remove kinetic typography module

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,9 +135,8 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
 .canvas.portrait{ aspect-ratio:4/5 }
 .canvas.landscape{ aspect-ratio:16/9 }
 .canvas .ghost{ opacity:.22; font-family:'Modak', cursive; letter-spacing:.04em }
-.canvas img{ width:80%; height:auto; }
+.canvas img{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; }
 .download{ margin-top:6px; font-size:12px; }
-.kinetic-frame{ width:100%; height:400px; border:0; border-radius:12px; }
 
 /* Section headings */
 h3.section{ font-family:'Sora', sans-serif; font-weight:400; margin:28px 0 12px; font-size:48px; letter-spacing:.01em }
@@ -161,10 +160,9 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <nav>
       <a href="#overview">Overview</a>
       <a href="#logo">Logo Usage</a>
-      <a href="#colors">Colors</a>
-      <a href="#kinetic">Kinetic Typography</a>
-      <a href="#type">Typography</a>
-      <a href="#templates">Social Templates</a>
+        <a href="#colors">Colors</a>
+        <a href="#type">Typography</a>
+        <a href="#templates">Social Templates</a>
       <a href="#photos">Photo Direction</a>
       <a href="#exports">Exports</a>
     </nav>
@@ -245,13 +243,8 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <p style="margin-top:10px; color:#555; font-size:13px">All UI and illustrations should reference these CSS tokens. Neutrals for surfaces; blues for hero/accents; rose sparingly.</p>
   </section>
 
-  <section id="kinetic" class="card" style="margin-top:22px">
-    <h3 class="section">Kinetic Typography</h3>
-    <iframe src="kinetic-typography.html" title="Kinetic Typography" class="kinetic-frame"></iframe>
-  </section>
-
-  <section id="type" class="card" style="margin-top:22px">
-    <h3 class="section">Typography</h3>
+    <section id="type" class="card" style="margin-top:22px">
+      <h3 class="section">Typography</h3>
     <div class="type-row">
       <div class="sample">
         <div class="cap">Display — Modak</div>


### PR DESCRIPTION
## Summary
- Center social template logos using max-fit sizing
- Drop kinetic typography section from main brand kit

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689a81cbaf98832a820e73f2f682daad