### PR TITLE
Add photo color guide with live camera suggestions

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -181,10 +181,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <nav>
       <a href="#overview">Overview</a>
       <a href="#logo">Logo Usage</a>
-        <a href="#colors">Colors</a>
-        <a href="#type">Typography</a>
-        <a href="#templates">Social Templates</a>
+      <a href="#colors">Colors</a>
+      <a href="#type">Typography</a>
+      <a href="#templates">Social Templates</a>
       <a href="#photos">Photo Direction</a>
+      <a href="photo-guide.html">Photo Tool</a>
       <a href="#exports">Exports</a>
     </nav>
   </header>

--- a/frontend/photo-guide.html
+++ b/frontend/photo-guide.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Photo Color Guide</title>
+  <link href="https://fonts.googleapis.com/css2?family=Modak&family=Sora:wght@300..800&display=swap" rel="stylesheet">
+  <style>
+    body{margin:0;padding:20px;font-family:'Sora',sans-serif;background:#f7f6f3;color:#111;}
+    header a{text-decoration:none;color:#111;}
+    h2{font-weight:500;}
+    video{width:100%;max-width:480px;border-radius:16px;background:#000;}
+    .controls{margin-top:14px;display:flex;gap:10px;flex-wrap:wrap;}
+    button{padding:8px 12px;border:none;border-radius:8px;background:#2c6fb1;color:#fff;font-weight:500;cursor:pointer;}
+    button:hover{background:#6fb1ff;color:#111;}
+    #suggestion{margin-top:14px;font-size:18px;font-weight:600;}
+    .swatches{display:flex;gap:10px;margin-top:10px;}
+    .swatch{width:40px;height:40px;border-radius:8px;box-shadow:0 0 0 2px rgba(0,0,0,.1);}
+  </style>
+</head>
+<body>
+  <header><a href="index.html">← Back to Brand Kit</a></header>
+  <h2>Photo Color Guide</h2>
+  <video id="video" autoplay playsinline></video>
+  <canvas id="canvas" width="200" height="150" style="display:none"></canvas>
+  <div class="controls">
+    <button id="filterBtn">Next Filter</button>
+    <button id="comboBtn">Suggest Color Combos</button>
+  </div>
+  <p id="suggestion">Allow camera access to begin.</p>
+  <div id="combos" class="swatches"></div>
+  <script src="photo-guide.js"></script>
+</body>
+</html>

--- a/frontend/photo-guide.js
+++ b/frontend/photo-guide.js
@@ -1,0 +1,75 @@
+const video = document.getElementById('video');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const suggestion = document.getElementById('suggestion');
+const combos = document.getElementById('combos');
+
+const palette = ['#2c6fb1','#6fb1ff','#1d3f73','#de9146','#111111','#dbb5c2','#efe5d7','#ebe9d5','#f3f0ec'];
+const filters = ['none','grayscale(100%)','sepia(60%)','contrast(160%)','brightness(120%)'];
+let filterIndex = 0;
+
+function luminance(hex){
+  const r = parseInt(hex.substr(1,2),16)/255;
+  const g = parseInt(hex.substr(3,2),16)/255;
+  const b = parseInt(hex.substr(5,2),16)/255;
+  return 0.2126*r + 0.7152*g + 0.0722*b;
+}
+
+function analyze(){
+  if(video.readyState >= 2){
+    ctx.drawImage(video,0,0,canvas.width,canvas.height);
+    const data = ctx.getImageData(0,0,canvas.width,canvas.height).data;
+    let r=0,g=0,b=0;
+    for(let i=0;i<data.length;i+=4){
+      r+=data[i]; g+=data[i+1]; b+=data[i+2];
+    }
+    const count = data.length/4;
+    r/=count; g/=count; b/=count;
+    const bright = (0.2126*r + 0.7152*g + 0.0722*b)/255;
+    let best = palette[0];
+    let bestScore = 0;
+    palette.forEach(c=>{
+      const contrast = Math.abs(luminance(c) - bright);
+      if(contrast > bestScore){ bestScore = contrast; best = c; }
+    });
+    suggestion.textContent = `Best color: ${best}`;
+    suggestion.style.color = best;
+  }
+  requestAnimationFrame(analyze);
+}
+
+navigator.mediaDevices.getUserMedia({video:true}).then(stream=>{
+  video.srcObject = stream;
+  requestAnimationFrame(analyze);
+}).catch(err=>{
+  suggestion.textContent = 'Camera access is required.';
+});
+
+function colorDistance(c,r,g,b){
+  const R=parseInt(c.substr(1,2),16);
+  const G=parseInt(c.substr(3,2),16);
+  const B=parseInt(c.substr(5,2),16);
+  return Math.sqrt((R-r)**2 + (G-g)**2 + (B-b)**2);
+}
+
+document.getElementById('filterBtn').addEventListener('click',()=>{
+  filterIndex = (filterIndex+1)%filters.length;
+  video.style.filter = filters[filterIndex];
+});
+
+document.getElementById('comboBtn').addEventListener('click',()=>{
+  ctx.drawImage(video,0,0,canvas.width,canvas.height);
+  const data = ctx.getImageData(0,0,canvas.width,canvas.height).data;
+  let r=0,g=0,b=0;
+  for(let i=0;i<data.length;i+=4){ r+=data[i]; g+=data[i+1]; b+=data[i+2]; }
+  const count = data.length/4;
+  r/=count; g/=count; b/=count;
+  const sorted = [...palette].sort((a,b)=> colorDistance(a,r,g,b) - colorDistance(b,r,g,b)).slice(0,3);
+  combos.innerHTML='';
+  sorted.forEach(c=>{
+    const div=document.createElement('div');
+    div.className='swatch';
+    div.style.background=c;
+    combos.appendChild(div);
+  });
+});


### PR DESCRIPTION
## Summary
- link to new photo tool from brand kit navigation
- add photo color guide page with camera access and filter cycling
- implement color analysis to suggest best brand colors and combinations

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689a9127c394832ab2bd43b337c2138b