### PR TITLE
Fix swatch click handler to avoid initialization crash

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -473,9 +473,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     updateLogo();
   });
 
-  document.querySelectorAll('.swatch').forEach(sw=>{
+  document.querySelectorAll('#colors .swatch').forEach(sw=>{
     sw.addEventListener('click',()=>{
-      const color=getComputedStyle(sw.querySelector('.chip')).backgroundColor;
+      const chip=sw.querySelector('.chip');
+      if(!chip) return;
+      const color=getComputedStyle(chip).backgroundColor;
       modal.style.background=color;
       modal.style.display='flex';
     });


### PR DESCRIPTION
## Summary
- Restrict color swatch modal listener to the Colors section and guard against missing chip elements to prevent runtime errors

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689afbc22a78832aa116721c9fa31faf