### PR TITLE
feat: add mobile menu toggle and smaller brand kit text

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,10 +75,14 @@ img{max-width:100%;height:auto}
 .brand h1 #titleLogo{height:100px;display:none;opacity:0;transition:opacity .4s;vertical-align:middle}
 .brand h1 #titleLogo.show{display:inline-block;opacity:1}
 .brand h1 .modak{font-family:'Modak', cursive;}
-.brand h1 .sora{font-family:'Sora', sans-serif;}
-@media(max-width:700px){ .brand h1{ font-size:32px } }
+.brand h1 .sora{font-family:'Sora', sans-serif;font-size:28px;}
+@media(max-width:700px){ .brand h1{ font-size:32px } .brand h1 .sora{font-size:18px} }
 
+.menu-wrap{display:flex;align-items:center;gap:14px}
+.menu-wrap #menuToggle{display:none;background:none;border:none;font-size:24px;cursor:pointer;padding:6px 10px;border-radius:8px}
+@media(max-width:700px){.menu-wrap #menuToggle{display:block}}
 .header nav{display:flex; gap:14px; flex-wrap:wrap}
+.header nav.hidden{display:none}
 .header a{ text-decoration:none; color:var(--ink); font-size:14px; opacity:.85; padding:6px 10px; border-radius:8px; }
 .header a:hover{ background:color-mix(in srgb, var(--blue2) 18%, transparent); }
 
@@ -208,18 +212,21 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <div class="dot"></div>
       <h1><span class="modak" id="titleText">A GRIEF<br>Like Mine</span><img id="titleLogo" src="https://i.ibb.co/DDXtHnk4/A-Grief-Like-Mine-Top-1-transparent.png" alt="AGLM logo"/><br><span class="sora">— Brand Kit</span></h1>
     </div>
-    <nav>
-      <a href="#overview">Overview</a>
-      <a href="#logo">Logo Usage</a>
-      <a href="#colors">Colors</a>
-      <a href="#type">Typography</a>
-      <a href="#templates">Social Templates</a>
-      <a href="#photos">Photo Direction</a>
-      <a href="photo-guide.html">Photo Tool</a>
-      <a href="#exports">Exports</a>
-      <button id="lightMode" class="btn secondary" type="button" aria-label="Light Mode">☀️</button>
-      <button id="darkMode" class="btn secondary" type="button" aria-label="Dark Mode">🌙</button>
-    </nav>
+    <div class="menu-wrap">
+      <button id="menuToggle" type="button" aria-label="Toggle menu">☰</button>
+      <nav>
+        <a href="#overview">Overview</a>
+        <a href="#logo">Logo Usage</a>
+        <a href="#colors">Colors</a>
+        <a href="#type">Typography</a>
+        <a href="#templates">Social Templates</a>
+        <a href="#photos">Photo Direction</a>
+        <a href="photo-guide.html">Photo Tool</a>
+        <a href="#exports">Exports</a>
+        <button id="lightMode" class="btn secondary" type="button" aria-label="Light Mode">☀️</button>
+        <button id="darkMode" class="btn secondary" type="button" aria-label="Dark Mode">🌙</button>
+      </nav>
+    </div>
   </header>
 
   <section id="overview" class="hero card">
@@ -1015,6 +1022,13 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       colorOverlay.style.display='block';
     });
   });
+})();
+
+// Menu toggle
+(function(){
+  const btn=document.getElementById('menuToggle');
+  const nav=document.querySelector('.header nav');
+  btn?.addEventListener('click',()=>nav?.classList.toggle('hidden'));
 })();
 
 // Light/Dark mode toggles


### PR DESCRIPTION
## Summary
- shrink "— Brand Kit" text on small screens for a tighter mobile header
- add a mobile-only menu toggle button to hide/show navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b0f24f5c8832ab8cab0f8661e3b35