### PR TITLE
Fix social template layout and video interactions

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -170,12 +170,21 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
 .templates{ display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:14px }
 .frame{ background:var(--card); border-radius:18px; padding:12px; box-shadow:var(--shadow) }
 .canvas{ border-radius:12px; background:var(--neutral3); display:grid; place-items:center; overflow:hidden }
+.canvas > *{ grid-area:1/1; }
 .canvas.square{ aspect-ratio:1/1 }
 .canvas.portrait{ aspect-ratio:4/5 }
 .canvas.landscape{ aspect-ratio:16/9 }
 .canvas .ghost{ opacity:.22; font-family:'Modak', cursive; letter-spacing:.04em }
-.canvas img{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; }
-.canvas video{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; }
+.canvas img{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; object-position:center; }
+.canvas video{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; object-position:center; }
+#photoExample .canvas img,
+#photoExample .canvas video{
+  width:100%;
+  height:100%;
+  max-width:none;
+  max-height:none;
+  object-fit:cover;
+}
 .download{ margin-top:6px; font-size:12px; }
 
 /* Section headings */
@@ -462,12 +471,12 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
 
       <div id="photoExample" class="templates" style="margin-top:20px;">
         <div class="frame">
-          <div class="canvas landscape">
+          <div class="canvas square">
             <img src="assets/photo%20tool.png" alt="Photo tool example"/>
           </div>
         </div>
         <div class="frame">
-          <div class="canvas landscape">
+          <div class="canvas square">
             <video id="photoExampleVideo" src="assets/Photo%20Tool.mp4" loop muted playsinline></video>
           </div>
         </div>
@@ -896,6 +905,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   }
   document.getElementById('cycleVideo')?.addEventListener('click',()=>{vidIdx=(vidIdx+1)%videos.length; render();});
   render();
+  vids.forEach(v=>{
+    v.addEventListener('mouseenter',()=>v.play());
+    v.addEventListener('mouseleave',()=>v.pause());
+    v.addEventListener('click',()=>{ if(v.paused) v.play(); else v.pause(); });
+  });
 
   document.querySelectorAll('.download-vid').forEach(btn=>btn.addEventListener('click',()=>{
     const a=document.createElement('a');


### PR DESCRIPTION
## Summary
- Ensure template content centers properly by overlaying canvas children
- Display photo tool examples in square modules without borders
- Add click-to-play controls for break animation videos

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b1f8f941c832a9b356c91cc8563aa