### PR TITLE
Improve video previews and photo tool interactions

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -183,6 +183,7 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
   height:auto;
 }
 .canvas video{ max-width:80%; max-height:80%; width:auto; height:auto; object-fit:contain; object-position:center; }
+#breakTemplates .canvas video{width:100%;height:100%;object-fit:cover;}
 .canvas .user-media{width:100%;height:100%;object-fit:cover;max-width:none;max-height:none;position:relative;z-index:1;}
 .canvas .template-img{position:relative;z-index:3;}
 .canvas .template-text{position:relative;z-index:2;color:#fff;font-family:'Sora',sans-serif;font-size:clamp(16px,5vw,32px);text-align:center;padding:10px;}
@@ -222,18 +223,21 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
 
 /* Photo tool */
 #photoTool{margin-top:20px;position:relative;}
-#photoTool video{width:100%;max-width:480px;border-radius:16px;background:#000;}
+#photoTool .camera-wrap{position:relative;width:100%;max-width:480px;}
+#photoTool .camera-wrap video{width:100%;border-radius:16px;background:#000;}
+#photoTool .camera-wrap canvas{position:absolute;top:0;left:0;width:100%;height:100%;display:none;}
 #photoTool .controls{margin-top:14px;display:flex;gap:10px;flex-wrap:wrap;}
 #photoTool button{padding:8px 12px;border:none;border-radius:8px;background:var(--blue1);color:#fff;font-weight:500;cursor:pointer;}
 #photoTool button:hover{background:var(--blue2);color:#111;}
 #photoTool #suggestion{margin-top:14px;font-size:18px;font-weight:600;}
 #photoTool .swatches{display:flex;gap:10px;margin-top:10px;}
 #photoTool .swatch{width:40px;height:40px;border-radius:8px;box-shadow:0 0 0 2px rgba(0,0,0,.1);}
-#photoTool .overlay{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);color:#fff;font-size:24px;text-align:center;pointer-events:none;z-index:2;}
-#photoTool #overlayLogo{width:120px;height:auto;}
-#photoTool #colorOverlay{position:absolute;inset:0;pointer-events:none;display:none;opacity:.3;z-index:1;}
+#photoTool .camera-wrap .overlay{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);color:#fff;font-size:24px;text-align:center;pointer-events:none;z-index:2;}
+#photoTool .camera-wrap #overlayLogo{width:120px;height:auto;}
+#photoTool .camera-wrap #colorOverlay{position:absolute;inset:0;pointer-events:none;display:none;opacity:.3;z-index:1;border-radius:16px;}
 #photoTool.fullscreen{position:fixed;inset:0;background:#000;z-index:1000;padding:0;}
-#photoTool.fullscreen video{width:100%;height:100%;object-fit:cover;}
+#photoTool.fullscreen .camera-wrap{width:100%;height:100%;}
+#photoTool.fullscreen .camera-wrap video{width:100%;height:100%;object-fit:cover;}
 #photoTool .fs-controls{display:none;position:absolute;top:10px;right:10px;left:auto;gap:8px;align-items:center;}
 #photoTool.fullscreen .fs-controls{display:flex;}
 #photoTool .fs-controls .swatch{width:30px;height:30px;border-radius:50%;cursor:pointer;box-shadow:0 0 0 2px rgba(0,0,0,.2);}
@@ -454,17 +458,17 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <div id="videoColors" class="swatches" style="margin-bottom:14px"></div>
     <div class="templates" id="breakTemplates">
       <div class="frame">
-        <div class="canvas square"><video class="break-video" loop muted playsinline></video><div class="ghost">1×1</div></div>
+        <div class="canvas square"><video class="break-video" loop muted playsinline autoplay></video><div class="ghost">1×1</div></div>
         <button class="download-vid" data-size="square" title="Download square animation">Download 1×1</button>
         <div style="font-size:12px; margin-top:6px; color:#555">Profile / Grid</div>
       </div>
       <div class="frame">
-        <div class="canvas portrait"><video class="break-video" loop muted playsinline></video><div class="ghost">4×5</div></div>
+        <div class="canvas portrait"><video class="break-video" loop muted playsinline autoplay></video><div class="ghost">4×5</div></div>
         <button class="download-vid" data-size="portrait" title="Download portrait animation">Download 4×5</button>
         <div style="font-size:12px; margin-top:6px; color:#555">IG Portrait</div>
       </div>
       <div class="frame">
-        <div class="canvas landscape"><video class="break-video" loop muted playsinline></video><div class="ghost">16×9</div></div>
+        <div class="canvas landscape"><video class="break-video" loop muted playsinline autoplay></video><div class="ghost">16×9</div></div>
         <button class="download-vid" data-size="landscape" title="Download landscape animation">Download 16×9</button>
         <div style="font-size:12px; margin-top:6px; color:#555">Video / YouTube</div>
       </div>
@@ -480,11 +484,13 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <li>Negative space for type; keep horizon lines calm.</li>
     </ul>
     <div id="photoTool">
-      <video id="video" playsinline></video>
-      <canvas id="canvas" width="200" height="150" style="display:none"></canvas>
-      <div id="overlayText" class="overlay" style="display:none"></div>
-      <img id="overlayLogo" class="overlay" alt="Overlay logo" style="display:none"/>
-      <div id="colorOverlay"></div>
+      <div class="camera-wrap">
+        <video id="video" playsinline></video>
+        <canvas id="canvas" width="200" height="150" style="display:none"></canvas>
+        <div id="overlayText" class="overlay" style="display:none"></div>
+        <img id="overlayLogo" class="overlay" alt="Overlay logo" style="display:none"/>
+        <div id="colorOverlay"></div>
+      </div>
       <div id="fsControls" class="fs-controls">
         <div class="swatch"></div>
         <div class="swatch"></div>
@@ -520,7 +526,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         </div>
         <div class="frame">
           <div class="canvas square">
-            <video id="photoExampleVideo" src="assets/Photo%20Tool.mp4" loop muted playsinline></video>
+            <video id="photoExampleVideo" src="assets/Photo%20Tool.mp4" loop muted playsinline autoplay></video>
           </div>
         </div>
       </div>
@@ -1079,7 +1085,9 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   vids.forEach(v=>{
     v.addEventListener('mouseenter',()=>v.play());
     v.addEventListener('mouseleave',()=>v.pause());
-    v.addEventListener('click',()=>{ if(v.paused) v.play(); else v.pause(); });
+    const toggle=()=>{ if(v.paused) v.play(); else v.pause(); };
+    v.addEventListener('click',toggle);
+    v.addEventListener('touchstart',e=>{ toggle(); e.preventDefault(); });
   });
 
   document.querySelectorAll('.download-vid').forEach(btn=>btn.addEventListener('click',()=>{
@@ -1133,11 +1141,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     if(video.readyState>=2){
       ctx.drawImage(video,0,0,canvas.width,canvas.height);
       const data=ctx.getImageData(0,0,canvas.width,canvas.height).data;
-      let r=0,g=0,b=0;
-      for(let i=0;i<data.length;i+=4){r+=data[i];g+=data[i+1];b+=data[i+2];}
+      let red=0,green=0,blue=0;
+      for(let i=0;i<data.length;i+=4){red+=data[i];green+=data[i+1];blue+=data[i+2];}
       const count=data.length/4;
-      r/=count;g/=count;b/=count;
-      const sorted=[...palette].sort((a,b)=>colorDistance(a,r,g,b)-colorDistance(b,r,g,b)).slice(0,3);
+      red/=count;green/=count;blue/=count;
+      const sorted=[...palette].sort((c1,c2)=>colorDistance(c1,red,green,blue)-colorDistance(c2,red,green,blue)).slice(0,3);
       combos.innerHTML='';
       const fsSwatches=fsControls.querySelectorAll('.swatch');
       sorted.forEach((c,i)=>{
@@ -1150,7 +1158,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           fsSwatches[i].dataset.color=c;
         }
       });
-      const bright=(0.2126*r+0.7152*g+0.0722*b)/255;
+      const bright=(0.2126*red+0.7152*green+0.0722*blue)/255;
       let best=palette[0],bestScore=0;
       palette.forEach(c=>{
         const contrast=Math.abs(luminance(c)-bright);
@@ -1182,11 +1190,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     suggestion.textContent='Camera inactive.';
   }
 
-  function colorDistance(c,r,g,b){
-    const R=parseInt(c.substr(1,2),16);
-    const G=parseInt(c.substr(3,2),16);
-    const B=parseInt(c.substr(5,2),16);
-    return Math.sqrt((R-r)**2 + (G-g)**2 + (B-b)**2);
+  function colorDistance(hex,rVal,gVal,bVal){
+    const R=parseInt(hex.substr(1,2),16);
+    const G=parseInt(hex.substr(3,2),16);
+    const B=parseInt(hex.substr(5,2),16);
+    return Math.sqrt((R-rVal)**2 + (G-gVal)**2 + (B-bVal)**2);
   }
 
   colorBtn?.addEventListener('click',()=>{
@@ -1317,9 +1325,10 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
 (function(){
   const v=document.getElementById('photoExampleVideo');
   if(!v) return;
-  v.addEventListener('mouseenter',()=>v.play());
-  v.addEventListener('mouseleave',()=>v.pause());
-  v.addEventListener('click',()=>{ if(v.paused) v.play(); else v.pause(); });
+  v.play().catch(()=>{});
+  const toggle=()=>{ if(v.paused) v.play(); else v.pause(); };
+  v.addEventListener('click',toggle);
+  v.addEventListener('touchstart',e=>{ toggle(); e.preventDefault(); });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Auto-play social template videos, with tap-to-toggle playback and proper aspect ratio previews
- Restrict photo tool overlays to camera view and auto-play example video with tap pause
- Fix live color analysis for full-screen photo tool to react to camera scene

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bbe6f7660832ab6174daf390ff13d