### PR TITLE
feat: add video recording and export capabilities to social templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Open `brand-guide.html` for a concise logo/color overview suitable for client re
 
 ## Updates
 
-- Social templates now accept uploaded photos or videos, let you overlay AGLM logos and custom text, support multiple aspect ratios, and export images. Video uploads are limited to 15 seconds.
+- Social templates now accept uploaded photos or recorded videos up to 60 seconds, let you overlay AGLM logos and custom text, support multiple aspect ratios, and export images or videos with overlays.
 - The photo tool's camera can cycle through brand colors with an overlay to help match the shooting environment.
 
 ## Deploying on Render

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -417,6 +417,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     <div style="display:flex;flex-wrap:wrap;gap:10px;margin-bottom:14px;align-items:center;">
       <label for="mediaUpload" class="btn secondary" title="Upload an image or short video">Upload Photo/Video</label>
       <input id="mediaUpload" type="file" accept="image/*,video/*" style="display:none" />
+      <button id="recordVideo" class="btn secondary" title="Record a short video">Record Video</button>
       <input id="templateText" type="text" placeholder="Add text" style="flex:1;min-width:120px" title="Enter overlay text" />
       <select id="templateFont" title="Choose text font">
         <option value="Sora">Sora</option>
@@ -891,12 +892,14 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   const ghosts=document.querySelectorAll('#logoTemplates .ghost');
   const colorWrap=document.getElementById('templateColors');
   const upload=document.getElementById('mediaUpload');
+  const recordBtn=document.getElementById('recordVideo');
   const textInput=document.getElementById('templateText');
   const fontSel=document.getElementById('templateFont');
   const posSel=document.getElementById('templateLogoPos');
   const removeBtn=document.getElementById('removeMedia');
   const toggleBtn=document.getElementById('toggleLogo');
   const shadowBtn=document.getElementById('toggleShadow');
+  let mediaRecorder=null; let recordedChunks=[];
   let logoPos='center';
 
   function fitText(el){
@@ -955,6 +958,35 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   posSel?.addEventListener('change',()=>{ logoPos=posSel.value; render(); });
   window.addEventListener('resize',()=>texts.forEach(t=>fitText(t)));
 
+  recordBtn?.addEventListener('click', async ()=>{
+    if(mediaRecorder && mediaRecorder.state!=='inactive'){
+      mediaRecorder.stop();
+      recordBtn.textContent='Record Video';
+      return;
+    }
+    try{
+      const stream=await navigator.mediaDevices.getUserMedia({video:true,audio:true});
+      recordedChunks=[];
+      mediaRecorder=new MediaRecorder(stream);
+      mediaRecorder.ondataavailable=e=>{ if(e.data.size>0) recordedChunks.push(e.data); };
+      mediaRecorder.onstop=()=>{
+        const blob=new Blob(recordedChunks,{type:'video/webm'});
+        stream.getTracks().forEach(t=>t.stop());
+        const url=URL.createObjectURL(blob);
+        const vid=document.createElement('video');
+        vid.src=url;
+        vid.onloadedmetadata=()=>{
+          if(vid.duration>60){ alert('Recorded video is longer than 60s.'); return; }
+          vid.loop=true; vid.muted=true; vid.playsInline=true; vid.play();
+          userMedia=vid; render();
+        };
+      };
+      mediaRecorder.start();
+      recordBtn.textContent='Stop Recording';
+      setTimeout(()=>{ if(mediaRecorder && mediaRecorder.state!=='inactive'){ mediaRecorder.stop(); recordBtn.textContent='Record Video'; } },60000);
+    }catch(err){ console.error(err); }
+  });
+
   upload?.addEventListener('change',e=>{
     const file=e.target.files?.[0];
     if(!file) return;
@@ -967,7 +999,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       const vid=document.createElement('video');
       vid.src=url;
       vid.onloadedmetadata=()=>{
-        if(vid.duration>15){ alert('Please select a video 15s or shorter.'); return; }
+        if(vid.duration>60){ alert('Please select a video 60s or shorter.'); return; }
         vid.loop=true; vid.muted=true; vid.playsInline=true; vid.play();
         userMedia=vid; render();
       };
@@ -977,6 +1009,10 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   render();
 
   function download(type){
+    if(userMedia && userMedia.tagName==='VIDEO'){
+      downloadVideo(type);
+      return;
+    }
     const map={square:[1080,1080],portrait:[1080,1350],landscape:[1920,1080]};
     const [w,h]=map[type];
     const canvas=document.createElement('canvas');
@@ -1052,6 +1088,67 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       }
       canvas.toBlob(b=>{const a=document.createElement('a');a.download=`AGLM_${type}.png`;a.href=URL.createObjectURL(b);a.click();URL.revokeObjectURL(a.href);});
     }
+  }
+
+  async function downloadVideo(type){
+    const map={square:[1080,1080],portrait:[1080,1350],landscape:[1920,1080]};
+    const [w,h]=map[type];
+    const canvas=document.createElement('canvas');
+    canvas.width=w; canvas.height=h;
+    const ctx=canvas.getContext('2d');
+    const stream=canvas.captureStream(30);
+    const recorder=new MediaRecorder(stream,{mimeType:'video/webm'});
+    const chunks=[];
+    recorder.ondataavailable=e=>{ if(e.data.size>0) chunks.push(e.data); };
+    recorder.onstop=()=>{
+      const blob=new Blob(chunks,{type:'video/webm'});
+      const a=document.createElement('a');
+      a.download=`AGLM_${type}.webm`;
+      a.href=URL.createObjectURL(blob);
+      a.click();
+    };
+    const vid=userMedia.cloneNode(true);
+    vid.loop=false; vid.muted=true; vid.playsInline=true;
+    const pos=posSel.value;
+    const text=textInput.value.trim();
+    let lw,lh,lx,ly,fontSize,textX=w/2,textY=h/2,textAlign='center',textBaseline='middle',maxWidth=w*0.9;
+    function calcText(){
+      fontSize=w/10;
+      ctx.font=`${fontSize}px ${fontSel.value}`;
+      while(text && ctx.measureText(text).width>maxWidth && fontSize>20){
+        fontSize-=2; ctx.font=`${fontSize}px ${fontSel.value}`;
+      }
+      switch(pos){
+        case 'left': textAlign='left'; textBaseline='middle'; textX=lx+lw+40; textY=h/2; break;
+        case 'right': textAlign='right'; textBaseline='middle'; textX=lx-40; textY=h/2; break;
+      }
+    }
+    function drawFrame(){
+      ctx.fillStyle=currentColor; ctx.fillRect(0,0,w,h);
+      const mw=vid.videoWidth, mh=vid.videoHeight;
+      const scale=Math.max(w/mw,h/mh);
+      const dw=mw*scale, dh=mh*scale;
+      ctx.drawImage(vid,(w-dw)/2,(h-dh)/2,dw,dh);
+      ctx.font=`${fontSize}px ${fontSel.value}`;
+      if(text){
+        ctx.fillStyle='#fff';
+        ctx.textAlign=textAlign;
+        ctx.textBaseline=textBaseline;
+        if(showShadow){ctx.shadowColor='rgba(0,0,0,.6)';ctx.shadowBlur=4;}
+        ctx.fillText(text,textX,textY);
+        if(showShadow){ctx.shadowColor='transparent';ctx.shadowBlur=0;}
+      }
+      if(showLogo) ctx.drawImage(logo,lx,ly,lw,lh);
+      if(!vid.paused && !vid.ended) requestAnimationFrame(drawFrame);
+    }
+    recorder.start();
+    vid.onended=()=>recorder.stop();
+    let logoLoaded=!showLogo;
+    const logo=new Image();
+    logo.crossOrigin='anonymous';
+    logo.onload=()=>{logoLoaded=true; lw=pos==='center'? w*0.6 : w*0.25; if(pos==='top'||pos==='bottom') lw=w*0.3; lh=lw*logo.height/logo.width; switch(pos){case 'center': lx=(w-lw)/2; ly=(h-lh)/2; break; case 'top': lx=(w-lw)/2; ly=40; break; case 'bottom': lx=(w-lw)/2; ly=h-lh-40; break; case 'left': lx=40; ly=(h-lh)/2; break; case 'right': lx=w-lw-40; ly=(h-lh)/2; break;} maxWidth=(pos==='left'||pos==='right')? w-lw-120 : w*0.9; calcText(); vid.play(); drawFrame();};
+    if(showLogo){ logo.src=logos[idx]; }
+    if(!showLogo){ calcText(); vid.play(); drawFrame(); }
   }
 
   document.querySelectorAll('.download').forEach(btn=>btn.addEventListener('click',()=>download(btn.dataset.size)));


### PR DESCRIPTION
## Summary
- allow social templates to record videos from webcam and reuse them as overlays
- bump video duration limit to 60 seconds
- export finalized videos with text/logo overlays

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bd2f64534832a97e5d93be37d1158