### PR TITLE
feat: interactive borders and dynamic color tools

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -169,7 +169,7 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
 /* Social templates */
 .templates{ display:grid; grid-template-columns:repeat(auto-fit, minmax(220px,1fr)); gap:14px }
 .frame{ background:var(--card); border-radius:18px; padding:12px; box-shadow:var(--shadow) }
-.canvas{ border-radius:12px; background:var(--neutral3); display:grid; place-items:center; overflow:hidden }
+.canvas{ position:relative; border-radius:12px; background:var(--neutral3); display:grid; place-items:center; overflow:hidden }
 .canvas > *{ grid-area:1/1; }
 .canvas.square{ aspect-ratio:1/1 }
 .canvas.portrait{ aspect-ratio:4/5 }
@@ -187,6 +187,7 @@ button.secondary{ background:#fff; color:var(--ink); border:1px solid color-mix(
 .canvas .user-media{width:100%;height:100%;object-fit:cover;max-width:none;max-height:none;position:relative;z-index:1;}
 .canvas .template-img{position:relative;z-index:3;}
 .canvas .template-text{position:relative;z-index:2;color:#fff;font-family:'Sora',sans-serif;font-size:clamp(16px,5vw,32px);text-align:center;padding:10px;}
+.border-overlay{position:absolute;inset:0;border-radius:12px;pointer-events:none;z-index:4;}
 
 /* Logo positioning helpers */
 .canvas.logo-center .template-img{width:80%;align-self:center;justify-self:center;}
@@ -341,6 +342,24 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <div class="swatch"><div class="chip" style="background:var(--rose)"></div><h4>Rose Accent</h4><code>#DBB5C2</code></div>
     </div>
     <p style="margin-top:10px; color:#555; font-size:13px">All UI and illustrations should reference these CSS tokens. Neutrals for surfaces; blues for hero/accents; rose sparingly.</p>
+    <div id="colorDayWrap" style="margin-top:20px;">
+      <button id="colorOfDayBtn" class="btn secondary">Color of the Day</button>
+      <div id="colorOfDayDisplay" class="swatch" style="margin-top:10px;display:none;">
+        <div class="chip"></div><h4>Color of the Day</h4><code></code>
+      </div>
+    </div>
+    <div style="margin-top:20px;">
+      <label>Color Wheel <input type="color" id="colorWheel" value="#2c6fb1" /></label>
+      <div id="complementaryDisplay" class="swatch" style="margin-top:10px;display:none;">
+        <div class="chip"></div><h4>Complementary</h4><code></code>
+      </div>
+    </div>
+    <div style="margin-top:20px;">
+      <label>Add Custom Color <input type="color" id="customColorPicker" /></label>
+      <button id="addCustomColor" class="btn secondary">Add Color</button>
+      <div id="customSwatches" class="swatches" style="margin-top:10px"></div>
+      <button id="downloadSwatches" class="btn secondary" style="margin-top:10px">Download Swatches</button>
+    </div>
   </section>
 
     <section id="type" class="card" style="margin-top:22px">
@@ -434,6 +453,37 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <button id="toggleLogo" class="btn secondary" title="Show or hide the logo">Hide Logo</button>
       <button id="toggleShadow" class="btn secondary" title="Toggle text shadow">Add Shadow</button>
       <button id="removeMedia" class="btn secondary" title="Remove uploaded media">Remove Media</button>
+      <label title="Border color" style="display:flex;align-items:center;gap:4px;">
+        Border
+        <select id="borderColor">
+          <option value="">None</option>
+          <option value="#2c6fb1">Primary Blue</option>
+          <option value="#6fb1ff">Sky</option>
+          <option value="#1d3f73">Deep Blue</option>
+          <option value="#de9146">Sunset</option>
+          <option value="#111111">Ink</option>
+          <option value="#dbb5c2">Rose</option>
+          <option value="#efe5d7">Oat</option>
+          <option value="#ebe9d5">Bone</option>
+          <option value="#f3f0ec">Porcelain</option>
+        </select>
+      </label>
+      <label title="Border width" style="display:flex;align-items:center;gap:4px;">
+        Width
+        <input id="borderWidth" type="number" value="0" min="0" max="40" style="width:60px" />
+      </label>
+      <label title="Text size" style="display:flex;align-items:center;gap:4px;">
+        Text Size
+        <input id="templateSize" type="range" min="12" max="72" value="32" />
+      </label>
+      <label title="Text horizontal position" style="display:flex;align-items:center;gap:4px;">
+        Text X
+        <input id="textX" type="range" min="-50" max="50" value="0" />
+      </label>
+      <label title="Text vertical position" style="display:flex;align-items:center;gap:4px;">
+        Text Y
+        <input id="textY" type="range" min="-50" max="50" value="0" />
+      </label>
     </div>
     <div id="templateColors" class="swatches" style="margin-bottom:14px"></div>
     <div class="templates" id="logoTemplates">
@@ -899,11 +949,18 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   const removeBtn=document.getElementById('removeMedia');
   const toggleBtn=document.getElementById('toggleLogo');
   const shadowBtn=document.getElementById('toggleShadow');
+  const sizeInput=document.getElementById('templateSize');
+  const textXInput=document.getElementById('textX');
+  const textYInput=document.getElementById('textY');
+  const borderColorSel=document.getElementById('borderColor');
+  const borderWidthInput=document.getElementById('borderWidth');
   let mediaRecorder=null; let recordedChunks=[];
   let logoPos='center';
+  let textX=0, textY=0;
+  let borderColor='', borderSize=0;
 
-  function fitText(el){
-    let size=32;
+  function fitText(el, base){
+    let size=base||32;
     el.style.fontSize=size+'px';
     const parent=el.parentElement;
     if(!parent) return;
@@ -934,6 +991,13 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       cv.style.background=currentColor;
       cv.classList.remove('logo-center','logo-top','logo-bottom','logo-left','logo-right');
       cv.classList.add('logo-'+logoPos);
+      cv.querySelector('.border-overlay')?.remove();
+      if(borderColor && borderSize>0){
+        const bo=document.createElement('div');
+        bo.className='border-overlay';
+        bo.style.border=`${borderSize}px solid ${borderColor}`;
+        cv.appendChild(bo);
+      }
       const old=cv.querySelector('.user-media');
       if(old) old.remove();
       if(userMedia){
@@ -945,7 +1009,14 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         cv.prepend(clone);
       }
     });
-    texts.forEach(t=>{ t.textContent=textInput.value; t.style.fontFamily=fontSel.value; t.style.textShadow=showShadow?'0 0 4px rgba(0,0,0,.6)':'none'; fitText(t); });
+    texts.forEach(t=>{
+      t.textContent=textInput.value;
+      t.style.fontFamily=fontSel.value;
+      t.style.textShadow=showShadow?'0 0 4px rgba(0,0,0,.6)':'none';
+      t.style.fontSize=(sizeInput?.value||32)+'px';
+      t.style.transform=`translate(${textX}%,${textY}%)`;
+      fitText(t, parseInt(sizeInput?.value||32,10));
+    });
     ghosts.forEach(g=> g.style.display=userMedia?'none':'block');
   }
 
@@ -956,7 +1027,12 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
   textInput?.addEventListener('input',render);
   fontSel?.addEventListener('change',render);
   posSel?.addEventListener('change',()=>{ logoPos=posSel.value; render(); });
-  window.addEventListener('resize',()=>texts.forEach(t=>fitText(t)));
+  sizeInput?.addEventListener('input',render);
+  textXInput?.addEventListener('input',()=>{ textX=parseInt(textXInput.value,10); render(); });
+  textYInput?.addEventListener('input',()=>{ textY=parseInt(textYInput.value,10); render(); });
+  borderColorSel?.addEventListener('change',()=>{ borderColor=borderColorSel.value; render(); });
+  borderWidthInput?.addEventListener('input',()=>{ borderSize=parseInt(borderWidthInput.value,10); render(); });
+  window.addEventListener('resize',()=>texts.forEach(t=>fitText(t, parseInt(sizeInput?.value||32,10))));
 
   recordBtn?.addEventListener('click', async ()=>{
     if(mediaRecorder && mediaRecorder.state!=='inactive'){
@@ -1068,6 +1144,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           if(showShadow){ctx.shadowColor='transparent';ctx.shadowBlur=0;}
         }
         ctx.drawImage(logo,lx,ly,lw,lh);
+        if(borderColor && borderSize>0){
+          ctx.strokeStyle=borderColor;
+          ctx.lineWidth=borderSize*2;
+          ctx.strokeRect(borderSize, borderSize, w-borderSize*2, h-borderSize*2);
+        }
         canvas.toBlob(b=>{const a=document.createElement('a');a.download=`AGLM_${type}.png`;a.href=URL.createObjectURL(b);a.click();URL.revokeObjectURL(a.href);});
       };
       logo.src=logos[idx];
@@ -1085,6 +1166,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         if(showShadow){ctx.shadowColor='rgba(0,0,0,.6)';ctx.shadowBlur=4;}
         ctx.fillText(text,w/2,h/2);
         if(showShadow){ctx.shadowColor='transparent';ctx.shadowBlur=0;}
+      }
+      if(borderColor && borderSize>0){
+        ctx.strokeStyle=borderColor;
+        ctx.lineWidth=borderSize*2;
+        ctx.strokeRect(borderSize, borderSize, w-borderSize*2, h-borderSize*2);
       }
       canvas.toBlob(b=>{const a=document.createElement('a');a.download=`AGLM_${type}.png`;a.href=URL.createObjectURL(b);a.click();URL.revokeObjectURL(a.href);});
     }
@@ -1111,6 +1197,8 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
     vid.loop=false; vid.muted=true; vid.playsInline=true;
     const pos=posSel.value;
     const text=textInput.value.trim();
+    const offsetXP=textX;
+    const offsetYP=textY;
     let lw,lh,lx,ly,fontSize,textX=w/2,textY=h/2,textAlign='center',textBaseline='middle',maxWidth=w*0.9;
     function calcText(){
       fontSize=w/10;
@@ -1122,6 +1210,8 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         case 'left': textAlign='left'; textBaseline='middle'; textX=lx+lw+40; textY=h/2; break;
         case 'right': textAlign='right'; textBaseline='middle'; textX=lx-40; textY=h/2; break;
       }
+      textX += offsetXP/100*w;
+      textY += offsetYP/100*h;
     }
     function drawFrame(){
       ctx.fillStyle=currentColor; ctx.fillRect(0,0,w,h);
@@ -1139,6 +1229,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         if(showShadow){ctx.shadowColor='transparent';ctx.shadowBlur=0;}
       }
       if(showLogo) ctx.drawImage(logo,lx,ly,lw,lh);
+      if(borderColor && borderSize>0){
+        ctx.strokeStyle=borderColor;
+        ctx.lineWidth=borderSize*2;
+        ctx.strokeRect(borderSize, borderSize, w-borderSize*2, h-borderSize*2);
+      }
       if(!vid.paused && !vid.ended) requestAnimationFrame(drawFrame);
     }
     recorder.start();
@@ -1385,6 +1480,133 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       colorOverlay.style.background=sw.dataset.color;
       colorOverlay.style.display='block';
     });
+  });
+})();
+
+// Brand color utilities
+(function(){
+  const brandPalette=['#2c6fb1','#6fb1ff','#1d3f73','#de9146','#111111','#dbb5c2','#efe5d7','#ebe9d5','#f3f0ec'];
+  let customColors=[];
+  const colorBtn=document.getElementById('colorOfDayBtn');
+  const colorDisplay=document.getElementById('colorOfDayDisplay');
+  colorBtn?.addEventListener('click',async()=>{
+    const c=await colorOfDay();
+    if(!c) return;
+    colorDisplay.style.display='block';
+    const chip=colorDisplay.querySelector('.chip');
+    const code=colorDisplay.querySelector('code');
+    chip.style.background=c; code.textContent=c;
+  });
+
+  async function colorOfDay(){
+    const now=new Date();
+    let timeFactor=now.getHours();
+    let weatherFactor=0;
+    try{
+      const pos=await new Promise((res,rej)=>{
+        if(!navigator.geolocation) return rej();
+        navigator.geolocation.getCurrentPosition(p=>res({lat:p.coords.latitude,lon:p.coords.longitude}),rej,{timeout:5000});
+      });
+      const resp=await fetch(`https://api.open-meteo.com/v1/forecast?latitude=${pos.lat}&longitude=${pos.lon}&current_weather=true`);
+      const data=await resp.json();
+      weatherFactor=Math.round(data.current_weather.temperature)%brandPalette.length;
+    }catch(e){}
+    const astroMap={Aries:0,Taurus:1,Gemini:2,Cancer:3,Leo:4,Virgo:5,Libra:6,Scorpio:7,Sagittarius:8,Capricorn:0,Aquarius:1,Pisces:2};
+    const astroFactor=astroMap[getAstroSign(now)]||0;
+    const idx=(timeFactor+weatherFactor+astroFactor)%brandPalette.length;
+    return brandPalette[idx];
+  }
+
+  function getAstroSign(d){
+    const m=d.getMonth()+1, day=d.getDate();
+    if((m==3&&day>=21)||(m==4&&day<=19)) return 'Aries';
+    if((m==4&&day>=20)||(m==5&&day<=20)) return 'Taurus';
+    if((m==5&&day>=21)||(m==6&&day<=20)) return 'Gemini';
+    if((m==6&&day>=21)||(m==7&&day<=22)) return 'Cancer';
+    if((m==7&&day>=23)||(m==8&&day<=22)) return 'Leo';
+    if((m==8&&day>=23)||(m==9&&day<=22)) return 'Virgo';
+    if((m==9&&day>=23)||(m==10&&day<=22)) return 'Libra';
+    if((m==10&&day>=23)||(m==11&&day<=21)) return 'Scorpio';
+    if((m==11&&day>=22)||(m==12&&day<=21)) return 'Sagittarius';
+    if((m==12&&day>=22)||(m==1&&day<=19)) return 'Capricorn';
+    if((m==1&&day>=20)||(m==2&&day<=18)) return 'Aquarius';
+    return 'Pisces';
+  }
+
+  const wheel=document.getElementById('colorWheel');
+  const compDisp=document.getElementById('complementaryDisplay');
+  wheel?.addEventListener('input',()=>{
+    const c=wheel.value;
+    const comp=getComplement(c);
+    compDisp.style.display='block';
+    compDisp.querySelector('.chip').style.background=comp;
+    compDisp.querySelector('code').textContent=comp;
+  });
+
+  function getComplement(hex){
+    const [h,s,l]=hexToHsl(hex);
+    return hslToHex((h+180)%360,s,l);
+  }
+  function hexToHsl(H){
+    let r=0,g=0,b=0;
+    H=H.replace('#','');
+    r=parseInt(H.substring(0,2),16)/255;
+    g=parseInt(H.substring(2,4),16)/255;
+    b=parseInt(H.substring(4,6),16)/255;
+    const max=Math.max(r,g,b), min=Math.min(r,g,b);
+    let h=0,s=0,l=(max+min)/2;
+    if(max!==min){
+      const d=max-min;
+      s=l>0.5? d/(2-max-min) : d/(max+min);
+      switch(max){
+        case r: h=(g-b)/d + (g<b?6:0); break;
+        case g: h=(b-r)/d + 2; break;
+        case b: h=(r-g)/d + 4; break;
+      }
+      h/=6;
+    }
+    return [h*360,s,l];
+  }
+  function hslToHex(h,s,l){
+    h/=360;
+    let r,g,b;
+    if(s===0){r=g=b=l;}else{
+      const q=l<0.5? l*(1+s) : l+s-l*s;
+      const p=2*l-q;
+      const hue2rgb=t=>{
+        if(t<0) t+=1;
+        if(t>1) t-=1;
+        if(t<1/6) return p+(q-p)*6*t;
+        if(t<1/2) return q;
+        if(t<2/3) return p+(q-p)*(2/3-t)*6;
+        return p;
+      };
+      r=hue2rgb(h+1/3); g=hue2rgb(h); b=hue2rgb(h-1/3);
+    }
+    const toHex=x=>Math.round(x*255).toString(16).padStart(2,'0');
+    return '#'+toHex(r)+toHex(g)+toHex(b);
+  }
+
+  const customPicker=document.getElementById('customColorPicker');
+  const customBtn=document.getElementById('addCustomColor');
+  const customWrap=document.getElementById('customSwatches');
+  customBtn?.addEventListener('click',()=>{
+    const c=customPicker.value;
+    customColors.push(c);
+    const sw=document.createElement('div');
+    sw.className='swatch';
+    sw.innerHTML=`<div class="chip" style="background:${c}"></div><h4>Custom</h4><code>${c}</code>`;
+    customWrap.appendChild(sw);
+  });
+
+  document.getElementById('downloadSwatches')?.addEventListener('click',()=>{
+    const all=[...brandPalette,...customColors];
+    const blob=new Blob([all.join('\n')],{type:'text/plain'});
+    const a=document.createElement('a');
+    a.download='AGLM_swatches.txt';
+    a.href=URL.createObjectURL(blob);
+    a.click();
+    URL.revokeObjectURL(a.href);
   });
 })();
 


### PR DESCRIPTION
## Summary
- allow social templates to overlay brand-colored borders and reposition text
- add color of the day, color wheel, and custom swatch download to brand colors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c61162718832a8636e92f18e89136