### PR TITLE
Enhance photo direction section and carousel generator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -534,9 +534,65 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         <option value="square">Square 1080×1080</option>
         <option value="portrait">Portrait 1080×1350</option>
       </select>
+      <select id="aglm-bg-color" title="Background color">
+        <option value="#2c6fb1">Blue 1</option>
+        <option value="#6fb1ff">Blue 2</option>
+        <option value="#1d3f73">Deep Blue</option>
+        <option value="#294b81">Blue A</option>
+        <option value="#6b89bd">Blue B</option>
+        <option value="#335694">Blue C</option>
+        <option value="#efe5d7">Oat</option>
+        <option value="#ebe9d5">Bone</option>
+        <option value="#f3f0ec">Porcelain</option>
+        <option value="#dbb5c2">Rose</option>
+        <option value="#111111">Ink</option>
+      </select>
+      <select id="aglm-accent-color" title="Accent color">
+        <option value="#2c6fb1">Blue 1</option>
+        <option value="#6fb1ff">Blue 2</option>
+        <option value="#1d3f73">Deep Blue</option>
+        <option value="#294b81">Blue A</option>
+        <option value="#6b89bd">Blue B</option>
+        <option value="#335694">Blue C</option>
+        <option value="#efe5d7">Oat</option>
+        <option value="#ebe9d5">Bone</option>
+        <option value="#f3f0ec">Porcelain</option>
+        <option value="#dbb5c2">Rose</option>
+        <option value="#111111">Ink</option>
+      </select>
       <input id="aglm-headline" type="text" placeholder="Headline" style="flex:1;min-width:120px" />
       <textarea id="aglm-details" placeholder="Details" style="flex:1;min-width:120px"></textarea>
       <input id="aglm-bg-url" type="url" placeholder="Background image URL (optional)" style="flex:1;min-width:120px" />
+      <input id="aglm-bg-file" type="file" accept="image/png,image/jpeg,image/webp,video/mp4" />
+      <select id="aglm-text-color" title="Text color">
+        <option value="#111111">Ink</option>
+        <option value="#ffffff">White</option>
+        <option value="#2c6fb1">Blue 1</option>
+        <option value="#6fb1ff">Blue 2</option>
+        <option value="#1d3f73">Deep Blue</option>
+        <option value="#294b81">Blue A</option>
+        <option value="#6b89bd">Blue B</option>
+        <option value="#335694">Blue C</option>
+        <option value="#efe5d7">Oat</option>
+        <option value="#ebe9d5">Bone</option>
+        <option value="#f3f0ec">Porcelain</option>
+        <option value="#dbb5c2">Rose</option>
+      </select>
+      <select id="aglm-logo-select" title="Logo">
+        <option value="0">Logo 1</option>
+        <option value="1">Logo 2</option>
+        <option value="2">Logo 3</option>
+      </select>
+      <select id="aglm-logo-pos" title="Logo position">
+        <option value="bottom-right">Bottom Right</option>
+        <option value="bottom-left">Bottom Left</option>
+        <option value="top-right">Top Right</option>
+        <option value="top-left">Top Left</option>
+      </select>
+      <input id="aglm-logo-size" type="number" value="300" min="50" max="600" title="Logo size" />
+      <input id="aglm-headline-size" type="number" value="70" min="20" max="200" title="Headline size" />
+      <input id="aglm-details-size" type="number" value="40" min="10" max="120" title="Details size" />
+      <input id="aglm-text-y" type="number" value="540" min="0" max="1000" title="Text Y position" />
       <button id="aglm-generate" class="btn secondary">Generate</button>
       <button id="aglm-download" class="btn secondary">Download PNG</button>
       <button id="aglm-print" class="btn secondary">Print/Save PDF</button>
@@ -585,8 +641,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           <input id="captionColor" type="color" value="#ffffff" style="display:none" title="Caption color" />
         </div>
       <p id="suggestion">Camera inactive.</p>
-      <div id="combos" class="swatches"></div>
-
+      <h4>Do</h4>
       <div id="photoExample" class="templates" style="margin-top:20px;">
         <div class="frame">
           <div class="canvas square">
@@ -599,11 +654,11 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           </div>
         </div>
       </div>
+      <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=4ARHEk46o" loading="lazy" style="width:100%;border:0;height:400px;margin-top:14px;"></iframe>
+      <div id="combos" class="swatches"></div>
     </div>
-    <h4>Do</h4>
-    <div id="aglm-do-gallery" class="templates"></div>
-    <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=4ARHEk46o" loading="lazy" style="width:100%;border:0;height:400px;margin-top:14px;"></iframe>
     <h4 style="margin-top:20px">Don't</h4>
+    <p style="font-size:14px;color:#555;margin-top:6px;">Upload your "don't" shots below. Submissions stay live for 30 days and the community can upvote to rank the top five.</p>
     <input id="aglm-dont-input" type="file" accept="image/png,image/jpeg,image/webp,video/mp4" multiple />
     <div id="aglm-dont-gallery" class="templates" style="margin-top:14px;"></div>
   </section>
@@ -1681,40 +1736,17 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
 })();
 </script>
 <style>
-  #aglm-do-gallery, #aglm-dont-gallery{display:flex;flex-wrap:wrap;gap:14px;margin-top:14px}
+  #aglm-dont-gallery{display:flex;flex-wrap:wrap;gap:14px;margin-top:14px}
   #aglm-dont-input{margin-top:10px}
   #aglm-pinterest{margin-top:14px;border-radius:12px}
   #aglm-carousel-controls textarea{min-height:60px}
   #aglm-carousel-canvas{margin-top:14px}
+  .rank{position:absolute;top:8px;left:8px;background:rgba(255,255,255,.9);padding:4px 6px;border-radius:6px;font-size:12px;font-weight:700;color:#333}
+  .vote-btn{position:absolute;bottom:8px;right:8px;border:none;background:var(--blue1);color:#fff;border-radius:50%;width:28px;height:28px;cursor:pointer;font-size:16px}
+  .vote-btn:hover{background:var(--blue2)}
 </style>
 <script>
 document.addEventListener('DOMContentLoaded',()=>{
-  const doGallery=document.getElementById('aglm-do-gallery');
-  if(doGallery){
-    const section=document.getElementById('photos');
-    const media=[...section.querySelectorAll('img,video')].filter(el=>{
-      const src=el.currentSrc||el.src||el.getAttribute('src');
-      return src&&/(\.png|\.jpe?g|\.webp|\.mp4)$/i.test(src)&&!el.closest('#aglm-do-gallery')&&!el.closest('#aglm-dont-gallery');
-    });
-    media.forEach(el=>{
-      const clone=el.cloneNode(true);
-      if(clone.tagName.toLowerCase()==='video'){
-        clone.removeAttribute('id');
-        clone.setAttribute('muted','');
-        clone.setAttribute('playsinline','');
-        clone.setAttribute('loop','');
-        clone.setAttribute('autoplay','');
-      }
-      const frame=document.createElement('div');
-      frame.className='frame';
-      const canvas=document.createElement('div');
-      canvas.className='canvas square';
-      canvas.appendChild(clone);
-      frame.appendChild(canvas);
-      doGallery.appendChild(frame);
-    });
-  }
-
   const key='aglm-dont-items';
   const dontInput=document.getElementById('aglm-dont-input');
   const dontGallery=document.getElementById('aglm-dont-gallery');
@@ -1727,9 +1759,15 @@ document.addEventListener('DOMContentLoaded',()=>{
   function renderDont(){
     if(!dontGallery) return;
     dontGallery.innerHTML='';
-    items.forEach(it=>{
+    const ranked=[...items].sort((a,b)=>(b.votes||0)-(a.votes||0)).slice(0,5);
+    ranked.forEach((it,idx)=>{
       const frame=document.createElement('div');
       frame.className='frame';
+      frame.style.position='relative';
+      const rank=document.createElement('div');
+      rank.className='rank';
+      rank.textContent='#'+(idx+1);
+      frame.appendChild(rank);
       const canvas=document.createElement('div');
       canvas.className='canvas square';
       let el;
@@ -1737,6 +1775,11 @@ document.addEventListener('DOMContentLoaded',()=>{
       else{el=document.createElement('img');el.src=it.data;}
       canvas.appendChild(el);
       frame.appendChild(canvas);
+      const vote=document.createElement('button');
+      vote.className='vote-btn';
+      vote.textContent='▲';
+      vote.addEventListener('click',()=>{it.votes=(it.votes||0)+1;localStorage.setItem(key,JSON.stringify(items));renderDont();});
+      frame.appendChild(vote);
       dontGallery.appendChild(frame);
     });
   }
@@ -1746,7 +1789,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     files.forEach(f=>{
       const r=new FileReader();
       r.onload=ev=>{
-        items.push({type:f.type.startsWith('video')?'video':'image',data:ev.target.result,time:Date.now()});
+        items.push({type:f.type.startsWith('video')?'video':'image',data:ev.target.result,time:Date.now(),votes:0});
         localStorage.setItem(key,JSON.stringify(items));
         renderDont();
       };
@@ -1765,38 +1808,87 @@ document.addEventListener('DOMContentLoaded',()=>{
     }
     ctx.fillText(line,x,y);
   }
+  const logos=[
+    'https://i.ibb.co/DDXtHnk4/A-Grief-Like-Mine-Top-1-transparent.png',
+    'https://i.ibb.co/rGKS5vTC/A-GRIEF-LIKE-MINE-Kinetic-Typography-transparent-Recovered.png',
+    'https://i.ibb.co/Lh8MQXSZ/A-GRIEF-LIKE-MINE-Kinetic-Typography-transparent-Recovered-2.png'
+  ];
   function draw(){
     if(!ctx) return;
     const type=document.getElementById('aglm-template-type').value;
     const aspect=document.getElementById('aglm-aspect').value;
     const headline=document.getElementById('aglm-headline').value;
     const details=document.getElementById('aglm-details').value;
-    const bg=document.getElementById('aglm-bg-url').value;
+    const bgUrl=document.getElementById('aglm-bg-url').value;
+    const bgFile=document.getElementById('aglm-bg-file').files[0];
+    const bgColor=document.getElementById('aglm-bg-color').value;
+    const accent=document.getElementById('aglm-accent-color').value;
+    const textColor=document.getElementById('aglm-text-color').value;
+    const logoIdx=parseInt(document.getElementById('aglm-logo-select').value,10);
+    const logoPos=document.getElementById('aglm-logo-pos').value;
+    const logoSize=parseInt(document.getElementById('aglm-logo-size').value,10)||300;
+    const headlineSize=parseInt(document.getElementById('aglm-headline-size').value,10)||70;
+    const detailsSize=parseInt(document.getElementById('aglm-details-size').value,10)||40;
+    const textY=parseInt(document.getElementById('aglm-text-y').value,10)||540;
     const w=1080,h=aspect==='square'?1080:1350;
     canvas.width=w;canvas.height=h;
-    ctx.fillStyle='#0C3C57';
+    ctx.fillStyle=bgColor;
     ctx.fillRect(0,0,w,h);
     const finish=()=>{
-      ctx.fillStyle='#D7A86E';
+      ctx.fillStyle=accent;
       ctx.fillRect(0,h-200,w,200);
-      ctx.fillStyle='#fff';
+      ctx.fillStyle=textColor;
       ctx.textAlign='center';
-      ctx.font='bold 80px Modak, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif';
-      ctx.fillText('AGLM',w/2,120);
-      ctx.font='bold 70px Modak, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif';
-      ctx.fillText(headline,w/2,h/2);
-      ctx.font='40px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
-      wrapText(details,w/2,h/2+80,w*0.8,50);
+      ctx.font=`bold ${headlineSize}px Modak, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif`;
+      wrapText(headline,w/2,textY,w*0.8,headlineSize*1.2);
+      ctx.font=`${detailsSize}px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif`;
+      wrapText(details,w/2,textY+headlineSize+20,w*0.8,detailsSize*1.25);
       ctx.font='italic 40px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
+      ctx.fillStyle='#fff';
       const footer=type==='save'?'Save the Date':'Event Announcement';
       ctx.fillText(footer,w/2,h-80);
+      const logo=new Image();
+      logo.crossOrigin='anonymous';
+      logo.onload=()=>{
+        const scale=logoSize/Math.max(logo.width,logo.height);
+        const dw=logo.width*scale;
+        const dh=logo.height*scale;
+        const posMap={
+          'bottom-right':[w-dw-50,h-dh-50],
+          'bottom-left':[50,h-dh-50],
+          'top-right':[w-dw-50,50],
+          'top-left':[50,50]
+        };
+        const [lx,ly]=posMap[logoPos];
+        ctx.drawImage(logo,lx,ly,dw,dh);
+      };
+      logo.src=logos[logoIdx];
     };
-    if(bg){
-      const img=new Image();
-      img.crossOrigin='anonymous';
-      img.onload=()=>{ctx.globalAlpha=0.25;ctx.drawImage(img,0,0,w,h);ctx.globalAlpha=1;finish();};
-      img.onerror=finish;
-      img.src=bg;
+    const handleFinish=()=>{ctx.globalAlpha=1;finish();};
+    if(bgFile){
+      if(bgFile.type.startsWith('video')){
+        const v=document.createElement('video');
+        v.src=URL.createObjectURL(bgFile);
+        v.onloadeddata=()=>{ctx.globalAlpha=0.25;ctx.drawImage(v,0,0,w,h);URL.revokeObjectURL(v.src);handleFinish();};
+        v.load();
+      }else{
+        const img=new Image();
+        img.onload=()=>{ctx.globalAlpha=0.25;ctx.drawImage(img,0,0,w,h);URL.revokeObjectURL(img.src);handleFinish();};
+        img.src=URL.createObjectURL(bgFile);
+      }
+    }else if(bgUrl){
+      if(/\.mp4$/i.test(bgUrl)){
+        const v=document.createElement('video');
+        v.crossOrigin='anonymous';
+        v.src=bgUrl;
+        v.onloadeddata=()=>{ctx.globalAlpha=0.25;ctx.drawImage(v,0,0,w,h);handleFinish();};
+      }else{
+        const img=new Image();
+        img.crossOrigin='anonymous';
+        img.onload=()=>{ctx.globalAlpha=0.25;ctx.drawImage(img,0,0,w,h);handleFinish();};
+        img.onerror=handleFinish;
+        img.src=bgUrl;
+      }
     }else finish();
   }
   document.getElementById('aglm-generate')?.addEventListener('click',draw);
@@ -1812,6 +1904,10 @@ document.addEventListener('DOMContentLoaded',()=>{
     w.document.close();
     w.focus();
     w.print();
+  });
+  document.getElementById('aglm-aspect')?.addEventListener('change',e=>{
+    const textY=document.getElementById('aglm-text-y');
+    textY.value=e.target.value==='square'?540:675;
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- Reorganize photo direction to show PNG/MP4 examples with a Do label, plus live Pinterest moodboard
- Clarify Don't area with 30-day upload notice and add a gamified ranking system for top five don'ts
- Expand carousel generator with brand color selectors, logo controls, text sizing/positioning, and mp4 background support

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e0fb385ec832aa3e267eeb96b43b5