### PR TITLE
Add font customization and high-res iOS support to carousel generator

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="apple-mobile-web-app-capable" content="yes"/>
+<meta name="apple-mobile-web-app-status-bar-style" content="default"/>
 <title>A GRIEF Like Mine — Brand Kit (2025)</title>
 
 <!-- Fonts: Modak + Sora sitewide. Sixtyfour is loaded but used ONLY for color names in the swatches. -->
@@ -565,6 +567,7 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
       <input id="aglm-bg-url" type="url" placeholder="Background image URL (optional)" style="flex:1;min-width:120px" />
       <input id="aglm-bg-file" type="file" accept="image/png,image/jpeg,image/webp,video/mp4" />
       <select id="aglm-text-color" title="Text color">
+        <option value="#000000">Black</option>
         <option value="#111111">Ink</option>
         <option value="#ffffff">White</option>
         <option value="#2c6fb1">Blue 1</option>
@@ -577,6 +580,17 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
         <option value="#ebe9d5">Bone</option>
         <option value="#f3f0ec">Porcelain</option>
         <option value="#dbb5c2">Rose</option>
+      </select>
+      <select id="aglm-font-family" title="Font family">
+        <option value="Sora" selected>Sora</option>
+        <option value="Modak">Modak</option>
+        <option value="system-ui">System Sans</option>
+      </select>
+      <select id="aglm-font-weight" title="Font weight">
+        <option value="400">Regular</option>
+        <option value="600">Semi Bold</option>
+        <option value="700" selected>Bold</option>
+        <option value="800">Extra Bold</option>
       </select>
       <select id="aglm-logo-select" title="Logo">
         <option value="0">Logo 1</option>
@@ -1800,6 +1814,7 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   const canvas=document.getElementById('aglm-carousel-canvas');
   const ctx=canvas?.getContext('2d');
+  if(ctx) ctx.imageSmoothingQuality='high';
   function wrapText(text,x,y,maxWidth,lineHeight){
     const words=text.split(' ');let line='';
     for(let n=0;n<words.length;n++){
@@ -1824,6 +1839,8 @@ document.addEventListener('DOMContentLoaded',()=>{
     const bgColor=document.getElementById('aglm-bg-color').value;
     const accent=document.getElementById('aglm-accent-color').value;
     const textColor=document.getElementById('aglm-text-color').value;
+    const fontFamily=document.getElementById('aglm-font-family').value;
+    const fontWeight=document.getElementById('aglm-font-weight').value;
     const logoIdx=parseInt(document.getElementById('aglm-logo-select').value,10);
     const logoPos=document.getElementById('aglm-logo-pos').value;
     const logoSize=parseInt(document.getElementById('aglm-logo-size').value,10)||300;
@@ -1831,7 +1848,9 @@ document.addEventListener('DOMContentLoaded',()=>{
     const detailsSize=parseInt(document.getElementById('aglm-details-size').value,10)||40;
     const textY=parseInt(document.getElementById('aglm-text-y').value,10)||540;
     const w=1080,h=aspect==='square'?1080:1350;
-    canvas.width=w;canvas.height=h;
+    const dpr=window.devicePixelRatio||1;
+    canvas.width=w*dpr;canvas.height=h*dpr;
+    ctx.setTransform(dpr,0,0,dpr,0,0);
     ctx.fillStyle=bgColor;
     ctx.fillRect(0,0,w,h);
     const finish=()=>{
@@ -1839,9 +1858,9 @@ document.addEventListener('DOMContentLoaded',()=>{
       ctx.fillRect(0,h-200,w,200);
       ctx.fillStyle=textColor;
       ctx.textAlign='center';
-      ctx.font=`bold ${headlineSize}px Modak, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif`;
+      ctx.font=`${fontWeight} ${headlineSize}px ${fontFamily}, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif`;
       wrapText(headline,w/2,textY,w*0.8,headlineSize*1.2);
-      ctx.font=`${detailsSize}px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif`;
+      ctx.font=`${fontWeight} ${detailsSize}px ${fontFamily}, system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif`;
       wrapText(details,w/2,textY+headlineSize+20,w*0.8,detailsSize*1.25);
       ctx.font='italic 40px system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif';
       ctx.fillStyle='#fff';


### PR DESCRIPTION
## Summary
- enable font family and weight selection for Instagram carousel generator
- default carousel text is Sora bold in black with easily labeled settings
- improve iOS readiness and canvas quality using device pixel ratio scaling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e141af3c8832aa0b5263bf5233f4f