### PR TITLE
feat: display Pinterest board in photo direction section

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -668,7 +668,8 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           </div>
         </div>
       </div>
-      <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=4ARHEk46o" loading="lazy" style="width:100%;border:0;height:400px;margin-top:14px;"></iframe>
+      <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=1oJPBxmYJ" loading="lazy" title="Photo direction inspiration board" style="width:100%;border:0;height:500px;margin-top:14px;"></iframe>
+      <p style="text-align:center;margin-top:8px;"><a href="https://pin.it/1oJPBxmYJ" target="_blank" rel="noopener">View the Pinterest inspiration board</a></p>
       <div id="combos" class="swatches"></div>
     </div>
     <h4 style="margin-top:20px">Don't</h4>


### PR DESCRIPTION
## Summary
- embed the Pinterest inspiration board for photo direction Do's
- provide direct link to the board for quick access

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e4e090608832aad045474bf3f0037