### PR TITLE
Embed Pinterest board in photo direction

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -668,7 +668,14 @@ footer{ margin-top:30px; color:#666; font-size:12px; text-align:center }
           </div>
         </div>
       </div>
-      <iframe id="aglm-pinterest" src="https://assets.pinterest.com/ext/embed.html?id=1oJPBxmYJ" loading="lazy" title="Photo direction inspiration board" style="width:100%;border:0;height:500px;margin-top:14px;"></iframe>
+      <div style="margin-top:14px;">
+        <a data-pin-do="embedBoard"
+           data-pin-board-width="800"
+           data-pin-scale-height="240"
+           data-pin-scale-width="80"
+           href="https://pin.it/1oJPBxmYJ"></a>
+        <script async defer src="https://assets.pinterest.com/js/pinit.js"></script>
+      </div>
       <p style="text-align:center;margin-top:8px;"><a href="https://pin.it/1oJPBxmYJ" target="_blank" rel="noopener">View the Pinterest inspiration board</a></p>
       <div id="combos" class="swatches"></div>
     </div>


### PR DESCRIPTION
## Summary
- embed Pinterest board below "Do" section for photo direction
- load Pinterest widget script so board photos render in the guide

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e548eb6d8832a9241512f62b99fab